### PR TITLE
build: Run tests only if CPPUnit is installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,12 @@ AM_INIT_AUTOMAKE([-Wall foreign])
 LT_INIT
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADER([config.h])
-AM_PATH_CPPUNIT(1.12)
+m4_ifdef([AM_PATH_CPPUNIT], [AM_PATH_CPPUNIT([1.12])], [AC_MSG_WARN([CPPUnit is not installed, it is needed to be able to run unit tests <http://cppunit.sourceforge.net/>])])
+AS_IF([test "x$CPPUNIT_LIBS" = "x"],
+	  [has_cppunit="no"],
+	  [has_cppunit="yes"])
+
+AM_CONDITIONAL([HAVE_CPPUNIT], [test "x$has_cppunit" = "xyes"])
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,6 @@
+if HAVE_CPPUNIT
 TESTS = TestColumnFilters
+
 check_PROGRAMS = $(TESTS)
 
 TEST_COLUMN_FILTERS_DEPS = StringColumnFilter.o CustomVarsFilter.o Column.o Filter.o
@@ -6,3 +8,4 @@ TestColumnFilters_SOURCES = $(top_builddir)/src/StringColumnFilter.h $(top_build
 TestColumnFilters_CXXFLAGS = $(CPPUNIT_FLAGS) -I$(top_builddir)
 TestColumnFilters_LDFLAGS = $(CPPUNIT_LIBS) -ldl -no-install
 TestColumnFilters_LDADD = $(top_builddir)/src/livestatus.la
+endif


### PR DESCRIPTION
This patch demotes a missing CPPUnit from an error to a warning, and
runs tests only if CPPUnit is installed on the system. For those who
don't have it installed, 0 tests are run if make check is invoked,
and no error is triggered.

Change-Id: I0414958cb26bd91762046934f27cde862608f95f
Signed-off-by: Anton Lofgren alofgren@op5.com
