### PR TITLE
Make TableDownComm storage thread safe

### DIFF
--- a/src/TableDownComm.h
+++ b/src/TableDownComm.h
@@ -28,6 +28,7 @@
 #include "config.h"
 
 #include <map>
+#include <pthread.h>
 #include "Table.h"
 #include "nagios.h"
 
@@ -43,6 +44,7 @@ class TableDownComm : public Table
     const char *_name;
     typedef map<unsigned long, DowntimeOrComment *> _entries_t;
     _entries_t _entries;
+    pthread_mutex_t _entries_mutex;
 
 public:
     TableDownComm(bool is_downtime);


### PR DESCRIPTION
The tables downtimes and comments uses an internal storage for
downtimes and comments, probably because the nagios and now naemons
internal storage doesn't provide thread safety, since objects can be
added and removed.

By some reason, the livestatus uses the non-thread safe storage map<>
from the standard library without synchronization. So adding or
removing downtimes at the same time as listing those can end up in
unexpected behaviour, and probably a segfault.

Easiest fix is to protect that map in a mutex.

More information can be found in the bugtracker at op5:
https://bugs.op5.com/view.php?id=8708

Signed-off-by: Max Sikstrom msikstrom@op5.com
