### PR TITLE
logger: Don't use non-literal as format string

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -100,7 +100,7 @@ void logger(int priority, const char *loginfo, ...)
         vsnprintf(buffer + strlen(buffer),
         sizeof(buffer) - strlen(buffer), loginfo, ap);
         va_end(ap);
-        nm_log(priority, buffer);
+        nm_log(priority, "%s", buffer);
     } else {
         lock_mutex_or_die(&g_log_file_mutex);
         if (g_logfile) {


### PR DESCRIPTION
While I don't believe we log buffers from untrusted sources anywhere,
it's bad practice to leave us open to such security holes.

This appeases -Wformat-security.

Signed-off-by: Anton Lofgren <alofgren@op5.com>