### PR TITLE
travis: fix hash sum mismatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - sudo apt-get install apt-transport-https
   - sudo sh -c "echo 'deb https://labs.consol.de/repo/testing/ubuntu $(lsb_release -cs) main' >> /etc/apt/sources.list"
   - wget -q "https://labs.consol.de/repo/stable/RPM-GPG-KEY" -O - | sudo apt-key add -
-  - sudo apt-get update
+  - sudo aptitude update
   - sudo apt-get install autoconf
   - sudo apt-get install build-essential
   - sudo apt-get install libcppunit-dev


### PR DESCRIPTION
there seems to be a bug in apt for quick changing apt repositories. Using aptitude
seem so solve the issue.

Signed-off-by: Sven Nierlein <sven@nierlein.de>