### PR TITLE
Add naemon to livestatus version

### DIFF
--- a/src/TableStatus.cc
+++ b/src/TableStatus.cc
@@ -158,7 +158,7 @@ TableStatus::TableStatus()
     addColumn(new IntPointerColumn("cached_log_messages",
                 "The current number of log messages Naemon Livestatus keeps in memory", &num_cached_log_messages ));
     addColumn(new StringPointerColumn("livestatus_version",
-                "The version of the Naemon Livestatus module", (char *)VERSION));
+                "The version of the Naemon Livestatus module", (char *)(VERSION"-naemon")));
 
     // Livecheck
 }


### PR DESCRIPTION
For the client APIs of livestatus, it is required to add `naemon` to the version.
So that clients can figure out it's `naemon-livestatus`.
Some client APIs might use `livestatus` from multiple vendors.
 