### PR TITLE
Modify  output of wrapped_json format

### DIFF
--- a/src/Query.cc
+++ b/src/Query.cc
@@ -858,7 +858,7 @@ void Query::start()
     {
         if (_output_format == OUTPUT_FORMAT_WRAPPED_JSON)
             _output->addString("{\"columns\":");
-        if (_output_format != OUTPUT_FORMAT_CSV)
+        if (_output_format != OUTPUT_FORMAT_CSV && _output_format != OUTPUT_FORMAT_WRAPPED_JSON)
             _output->addChar('[');
 
         outputDatasetBegin();
@@ -896,7 +896,7 @@ void Query::start()
 
         if (_output_format == OUTPUT_FORMAT_WRAPPED_JSON)
         {
-            _output->addString("],\"data\":[");
+            _output->addString(",\"data\":[");
             // Since this delimiter is a special kind of dataset separator, the
             // next data set should not have one implicitly, since one is
             // written here

--- a/tests/features/wrapped_json_output.feature
+++ b/tests/features/wrapped_json_output.feature
@@ -31,9 +31,9 @@ Feature: JSON output works as intended
 		Then I should see the following livestatus response, ignoring whitespace
 			"""
 			{
-				"columns":[
+				"columns":
 					["name"]
-				],
+				,
 				"data":[
 					["host1"],
 					["host2"]
@@ -53,9 +53,9 @@ Feature: JSON output works as intended
 		Then I should see the following livestatus response, ignoring whitespace
 			"""
 			{
-				"columns":[
+				"columns":
 					["name"]
-				],
+				,
 				"data":[
 					["host3"],
 					["host2"]
@@ -73,9 +73,9 @@ Feature: JSON output works as intended
 		Then I should see the following livestatus response, ignoring whitespace
 			"""
 			{
-				"columns":[
+				"columns":
 					["stats_1"]
-				],
+				,
 				"data":[
 					[3]
 				],
@@ -93,9 +93,9 @@ Feature: JSON output works as intended
 		Then I should see the following livestatus response, ignoring whitespace
 			"""
 			{
-				"columns":[
+				"columns":
 					["name", "stats_1"]
-				],
+				,
 				"data":[
 					["host1", 1],
 					["host2", 1],


### PR DESCRIPTION
The wrapped json outputs in the following format ("columns" field has extra brackets "[]"):
{
  "columns": [["name"]],
  "data": [ ... ]
...
}

This fix addresses this issue.