### PR TITLE
Travis: Run cucumber tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ script:
   - make
 after_success:
   - make check || exit 1
+  - export CUKE_CLOBBER_PATH=$TRAVIS_BUILD_DIR/tests/tools/ls-clobber
+  - export CUKE_UNIXCAT_PATH=$TRAVIS_BUILD_DIR/src/unixcat
+  - export CUKE_LIVESTATUS_PATH=$TRAVIS_BUILD_DIR/src/.libs/livestatus.so
+  - cucumber ./tests -t ~@skip -t ~@unreliable --strict || exit 1
 before_install:
   - sudo apt-get update
   - sudo apt-get install apt-transport-https
@@ -20,6 +24,9 @@ before_install:
   - sudo apt-get install libcppunit-dev
   - sudo apt-get install libglib2.0-dev
   - sudo apt-get install naemon-dev
+  - sudo apt-get install naemon-core
+  - sudo apt-get install ruby ruby-dev
+  - gem install cucumber:1.3.18 websocket-driver:0.7.0 nokogiri:1.6.0 rack:1.6.5 rack-test:0.7.0 capybara:2.1.0 public_suffix:2.0.5 xpath:2.0 rspec:2.14.1 parallel_tests syntax:1.0.0 cliver:0.3.2
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: c
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ after_success:
 before_install:
   - sudo apt-get update
   - sudo apt-get install apt-transport-https
-  - sudo sh -c "echo 'deb https://labs.consol.de/repo/testing/ubuntu $(lsb_release -cs) main' >> /etc/apt/sources.list"
-  - wget -q "https://labs.consol.de/repo/stable/RPM-GPG-KEY" -O - | sudo apt-key add -
+  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/naemon:/daily/xUbuntu_$(lsb_release -rs)/ ./' >> /etc/apt/sources.list"
+  - wget -q "https://build.opensuse.org/projects/home:naemon:daily/public_key" -O - | sudo apt-key add -
   - sudo aptitude update
   - sudo apt-get install autoconf
   - sudo apt-get install build-essential

--- a/tests/features/support/naemon.rb
+++ b/tests/features/support/naemon.rb
@@ -119,7 +119,7 @@ class Livestatus < NaemonModule
     else
       unixcat = "unixcat"
     end
-    cmd = "echo -e \"#{q}\"| #{unixcat} #{@sockpath}"
+    cmd = "/bin/echo -e \"#{q}\"| #{unixcat} #{@sockpath}"
     @last_response = `#{cmd}`.split("\n")
   end
   


### PR DESCRIPTION
We never ran the full cucumber test suite with Travis-CI. This PR ensures that all tests are run, so we can verify pull requests do not fail tests before merging.

This pull request:

- Runs Travis with Ubuntu 16.04 due to various problems with 14.04 (https://github.com/travis-ci/travis-ci/issues/8906)
- Runs the cucumber tests with Travis
- Uses /bin/echo instead of inbuilt shell echo command for running tests
- Uses the OBS repo for the neamon packages instead of the consol.de ones