### PR TITLE
use icu:: namespace when required (fixes #30)

### DIFF
--- a/src/CustomVarsFilter.cc
+++ b/src/CustomVarsFilter.cc
@@ -68,8 +68,8 @@ with spaces
             }
             else {
 #ifdef HAVE_ICU
-                UnicodeString s = UnicodeString::fromUTF8(search_space);
-                _regex_matcher = new RegexMatcher(s, (_opid == OP_REGEX_ICASE ? UREGEX_CASE_INSENSITIVE : 0), status);
+                icu::UnicodeString s = icu::UnicodeString::fromUTF8(search_space);
+                _regex_matcher = new icu::RegexMatcher(s, (_opid == OP_REGEX_ICASE ? UREGEX_CASE_INSENSITIVE : 0), status);
                 if (U_FAILURE(status))
                 {
                     setError(RESPONSE_CODE_INVALID_HEADER, "invalid regular expression '%s'", value);
@@ -122,7 +122,7 @@ bool CustomVarsFilter::accepts(void *data)
             case OP_REGEX_ICASE:
 #ifdef HAVE_ICU
                 if ( _regex_matcher != 0) {
-                    UnicodeString s = UnicodeString::fromUTF8(act_string);
+                    icu::UnicodeString s = icu::UnicodeString::fromUTF8(act_string);
                     _regex_matcher->reset(s);
                     _regex_matcher->reset(act_string);
                     pass = _regex_matcher->find();

--- a/src/CustomVarsFilter.h
+++ b/src/CustomVarsFilter.h
@@ -42,7 +42,7 @@ class CustomVarsFilter : public Filter
     bool _negate;
     string _ref_text;
 #ifdef HAVE_ICU
-    RegexMatcher * _regex_matcher;
+    icu::RegexMatcher * _regex_matcher;
 #else
     regex_t *_regex;
 #endif

--- a/src/StringColumnFilter.cc
+++ b/src/StringColumnFilter.cc
@@ -50,8 +50,8 @@
         }
         else {
 #ifdef HAVE_ICU
-            UnicodeString s = UnicodeString::fromUTF8(value);
-            _regex_matcher = new RegexMatcher(s, (_opid == OP_REGEX_ICASE ? UREGEX_CASE_INSENSITIVE : 0), status);
+            icu::UnicodeString s = icu::UnicodeString::fromUTF8(value);
+            _regex_matcher = new icu::RegexMatcher(s, (_opid == OP_REGEX_ICASE ? UREGEX_CASE_INSENSITIVE : 0), status);
             if (U_FAILURE(status)) {
                 setError(RESPONSE_CODE_INVALID_HEADER, "invalid regular expression '%s'", value);
                 delete _regex_matcher;
@@ -98,7 +98,7 @@ bool StringColumnFilter::accepts(void *data)
         case OP_REGEX_ICASE:
 #ifdef HAVE_ICU
             if ( _regex_matcher != 0 ) {
-                UnicodeString s = UnicodeString::fromUTF8(act_string);
+                icu::UnicodeString s = icu::UnicodeString::fromUTF8(act_string);
                 _regex_matcher->reset(s);
                 pass = _regex_matcher->find();
             }

--- a/src/StringColumnFilter.h
+++ b/src/StringColumnFilter.h
@@ -47,7 +47,7 @@ class StringColumnFilter : public Filter
     int _opid;
     bool _negate;
 #ifdef HAVE_ICU
-    RegexMatcher *_regex_matcher;
+    icu::RegexMatcher *_regex_matcher;
 #else
     regex_t *_regex;
 #endif


### PR DESCRIPTION
with gcc 8 (might be related to the libicu version 1.62 as well) livestatus
ftbfs with error: 'RegexMatcher' does not name a type. You need to explicitly
use the icu namespace.