### PR TITLE
Send command response

### DIFF
--- a/src/OutputBuffer.cc
+++ b/src/OutputBuffer.cc
@@ -93,26 +93,24 @@ void OutputBuffer::needSpace(unsigned len)
 
 void OutputBuffer::flush(int fd, int *termination_flag)
 {
+    const char *buffer = _buffer;
+    int s = size();
+    // if response code is not OK, output error
+    // message instead of data
+    if (_response_code != RESPONSE_CODE_OK)
+    {
+        buffer = _error_message.c_str();
+        s = _error_message.size();
+    }
     if (_response_header == RESPONSE_HEADER_FIXED16)
     {
-        const char *buffer = _buffer;
-        int s = size();
-
-        // if response code is not OK, output error
-        // message instead of data
-        if (_response_code != RESPONSE_CODE_OK)
-        {
-            buffer = _error_message.c_str();
-            s = _error_message.size();
-        }
-
         char header[17];
         snprintf(header, sizeof(header), "%03d %11d\n", _response_code, s);
         writeData(fd, termination_flag, header, 16);
         writeData(fd, termination_flag, buffer, s);
     }
     else
-        writeData(fd, termination_flag, _buffer, size());
+        writeData(fd, termination_flag, buffer, s);
     reset();
 }
 
@@ -161,4 +159,3 @@ void OutputBuffer::setError(unsigned code, const char *format, ...)
         _response_code = code;
     }
 }
-

--- a/src/Store.cc
+++ b/src/Store.cc
@@ -149,7 +149,7 @@ bool Store::answerRequest(InputBuffer *input, OutputBuffer *output)
 void Store::answerCommandRequest(const char *command)
 {
     int ret, sd;
-    char *buf;
+    char buf[4096];
     sd = nsock_unix(qh_socket_path, NSOCK_TCP | NSOCK_CONNECT);
     if (sd < 0) {
         logger(LG_INFO, "Failed to connect to query socket '%s': %s: %s", qh_socket_path, nsock_strerror(sd), strerror(errno));
@@ -159,8 +159,9 @@ void Store::answerCommandRequest(const char *command)
     if (ret < 0) {
         logger(LG_INFO, "failed to submit command by query handler");
     }
-    while(read(sd, buf, 1024) > 0) {
-        logger(LG_INFO, "query handler: %s\n", buf);
+    while(read(sd, buf, 4095) > 0) {
+        rstrip(buf);
+        logger(LG_INFO, "query handler: %s", rstrip(buf));
     }
     close(sd);
     return;

--- a/src/Store.h
+++ b/src/Store.h
@@ -74,7 +74,7 @@ public:
 private:
     Table *findTable(string name);
     void answerGetRequest(InputBuffer *, OutputBuffer *, const char *);
-    void answerCommandRequest(const char *);
+    void answerCommandRequest(const char *, OutputBuffer *);
 };
 
 #endif // Store_h


### PR DESCRIPTION
so the client has a chance to detect failed commands. This
should not break(tm) existing setups, because it changes the output
only if the command was unsuccessful.