### PR TITLE
release 1.0.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+naemon-livestatus (1.0.9) UNRELEASED; urgency=low
+
+  * new upstream release
+
+ -- Naemon Development Team <naemon-dev@monitoring-lists.org>  Tue, 18 Dec 2018 13:08:21 +0100
+
 naemon-livestatus (1.0.8) UNRELEASED; urgency=low
 
   * new upstream release

--- a/naemon-livestatus.spec
+++ b/naemon-livestatus.spec
@@ -8,7 +8,7 @@
 
 Summary: Naemon Livestatus Eventbroker Module
 Name: naemon-livestatus
-Version: 1.0.8
+Version: 1.0.9
 Release: 0
 License: GPLv2
 Group: Applications/System

--- a/version.sh
+++ b/version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=1.0.8
+VERSION=1.0.9
 if test -e .git; then
     if hash git 2>/dev/null; then
         VERSION=$(git describe --tag --exact-match 2>/dev/null | sed -e 's/^v//')


### PR DESCRIPTION
Since there is now changelog file (yet?)

1.0.9
  - make listen() backlog adjustable with 'max_backlog' option
  - pass errors from the query handler back to the client
  - report command errors back via livestatus COMMAND requests