### PR TITLE
fix segfault when accessing downtimes/comments

### DIFF
--- a/src/DownCommColumn.cc
+++ b/src/DownCommColumn.cc
@@ -32,6 +32,7 @@
 void DownCommColumn::output(void *data, Query *query)
 {
     TableDownComm *table = _is_downtime ? g_table_downtimes : g_table_comments;
+    table->lock();
     query->outputBeginList();
     data = shiftPointer(data); // points to host or service
     if (data)
@@ -66,6 +67,7 @@ void DownCommColumn::output(void *data, Query *query)
             }
         }
     }
+    table->unlock();
     query->outputEndList();
 }
 
@@ -92,6 +94,7 @@ bool DownCommColumn::isEmpty(void *data)
     if (!data) return true;
 
     TableDownComm *table = _is_downtime ? g_table_downtimes : g_table_comments;
+    table->lock();
     for (map<unsigned long, DowntimeOrComment *>::iterator it = table->entriesIteratorBegin();
             it != table->entriesIteratorEnd();
             ++it)
@@ -100,8 +103,10 @@ bool DownCommColumn::isEmpty(void *data)
         if ((void *)dt->_service == data ||
                 (dt->_service == 0 && dt->_host == data))
         {
+            table->unlock();
             return false;
         }
     }
+    table->unlock();
     return true; // empty
 }

--- a/src/TableDownComm.cc
+++ b/src/TableDownComm.cc
@@ -36,9 +36,6 @@
 #include <pthread.h>
 #include <string.h>
 
-// Todo: the dynamic data in this table must be
-// locked with a mutex
-
 TableDownComm::TableDownComm(bool is_downtime)
 {
     int err;
@@ -258,4 +255,24 @@ DowntimeOrComment *TableDownComm::findEntry(unsigned long id)
     return res;
 }
 
+void TableDownComm::lock()
+{
+    int err;
+    char errmsg[256] = "unknown error";
+    err = pthread_mutex_lock(&_entries_mutex);
+    if(err) {
+        strerror_r(err, errmsg, 256);
+        logger(LG_INFO, "Error locking mutex: %s (%d)", errmsg, err);
+    }
+}
 
+void TableDownComm::unlock()
+{
+    int err;
+    char errmsg[256] = "unknown error";
+    err = pthread_mutex_unlock(&_entries_mutex);
+    if(err) {
+        strerror_r(err, errmsg, 256);
+        logger(LG_INFO, "Error unlocking mutex: %s (%d)", errmsg, err);
+    }
+}

--- a/src/TableDownComm.h
+++ b/src/TableDownComm.h
@@ -59,8 +59,9 @@ public:
     bool isAuthorized(contact *ctc, void *data);
     _entries_t::iterator entriesIteratorBegin() { return _entries.begin(); }
     _entries_t::iterator entriesIteratorEnd() { return _entries.end(); }
+    void lock();
+    void unlock();
 };
 
 
 #endif // TableDownComm_h
-


### PR DESCRIPTION
when retrieving downtime/comment related information from the hosts/services
table we need to lock downtimes/comments data in the same way as it's done when
requesting downtime/comment tables directly. Otherwise naemon will segfault
when requesting ex.: "GET hosts\nColumns: comments" while comments are added or
removed while the request is processed.

Therefor we expose the table lock and make sure we use locking when gathering
those columns.

Signed-off-by: Sven Nierlein <sven@nierlein.de>