### PR TITLE
Correct columns description for Log, Class

### DIFF
--- a/src/TableLog.cc
+++ b/src/TableLog.cc
@@ -83,7 +83,7 @@ TableLog::TableLog(unsigned long max_cached_messages)
     addColumn(new OffsetIntColumn("lineno",
                 "The number of the line in the log file", (char *)&(ref->_lineno) - (char *)ref, -1));
     addColumn(new OffsetIntColumn("class",
-                "The class of the message as integer (0:info, 1:state, 2:program, 3:notification, 4:passive, 5:command)", (char *)&(ref->_logclass) - (char *)ref, -1));
+                "The class of the message as integer (0:info, 1:alert, 2:program, 3:notification, 4:passive, 5:command, 6:state)", (char *)&(ref->_logclass) - (char *)ref, -1));
 
     addColumn(new OffsetStringColumn("message",
                 "The complete message line including the timestamp", (char *)&(ref->_complete) - (char *)ref, -1));


### PR DESCRIPTION
According to the code (https://github.com/naemon/naemon-livestatus/blob/c735ec422ab6259e8543de21e4804b2de19103f7/src/LogEntry.h#L29), alert is defined as 1 and
state as 6. This commit adjusts the description to match the actual
states used.

Signed-off-by: Jacob Hansen <jhansen@op5.com>