### PR TITLE
fix race condition during core reload on long running queries

### DIFF
--- a/src/OutputBuffer.h
+++ b/src/OutputBuffer.h
@@ -43,6 +43,7 @@ using namespace std;
 
 class OutputBuffer
 {
+    int *_termination_flag;
     char *_buffer;
     char *_writepos;
     char *_end;
@@ -53,7 +54,7 @@ class OutputBuffer
     bool _do_keepalive;
 
 public:
-    OutputBuffer();
+    OutputBuffer(int *termination_flag);
     ~OutputBuffer();
     const char *buffer() { return _buffer; }
     unsigned size() { return _writepos - _buffer; }
@@ -61,7 +62,8 @@ public:
     void addString(const char *);
     void addBuffer(const char *, unsigned);
     void reset();
-    void flush(int fd, int *termination_flag);
+    void flush(int fd);
+    bool shouldTerminate();
     void setResponseHeader(int r) { _response_header = r; }
     int responseHeader() { return _response_header; }
     void setDoKeepalive(bool d) { _do_keepalive = d; }
@@ -71,9 +73,8 @@ public:
 
 private:
     void needSpace(unsigned);
-    void writeData(int fd, int *, const char *, int);
+    void writeData(int fd, const char *, int);
 };
 
 
 #endif // OutputBuffer_h
-

--- a/src/module.c
+++ b/src/module.c
@@ -179,7 +179,7 @@ static int accept_connection(int sd, int events, void *discard)
 void *client_thread(void *data)
 {
     void *input_buffer = create_inputbuffer(&g_should_terminate);
-    void *output_buffer = create_outputbuffer();
+    void *output_buffer = create_outputbuffer(&g_should_terminate);
 
     int cc = *((int *)data);
     free(data);
@@ -193,7 +193,7 @@ void *client_thread(void *data)
             if (g_debug_level >= 2 && requestnr > 1)
                 logger(LG_INFO, "Handling request %d on same connection", requestnr);
             keepalive = store_answer_request(input_buffer, output_buffer);
-            flush_output_buffer(output_buffer, cc, &g_should_terminate);
+            flush_output_buffer(output_buffer, cc);
             g_counters[COUNTER_REQUESTS]++;
             requestnr ++;
         }

--- a/src/store.cc
+++ b/src/store.cc
@@ -80,14 +80,14 @@ int store_answer_request(void *ib, void *ob)
     return g_store->answerRequest((InputBuffer *)ib, (OutputBuffer *)ob);
 }
 
-void *create_outputbuffer()
+void *create_outputbuffer(int *termination_flag)
 {
-    return new OutputBuffer();
+    return new OutputBuffer(termination_flag);
 }
 
-void flush_output_buffer(void *ob, int fd, int *termination_flag)
+void flush_output_buffer(void *ob, int fd)
 {
-    ((OutputBuffer *)ob)->flush(fd, termination_flag);
+    ((OutputBuffer *)ob)->flush(fd);
 }
 
 void delete_outputbuffer(void *ob)
@@ -114,4 +114,3 @@ void update_timeperiods_cache(time_t now)
 {
     g_timeperiods_cache->update(now);
 }
-

--- a/src/store.h
+++ b/src/store.h
@@ -37,8 +37,8 @@ extern "C"
     void store_register_comment(nebstruct_comment_data *);
     void store_register_downtime(nebstruct_downtime_data *);
     int  store_answer_request(void *input_buffer, void *output_buffer);
-    void *create_outputbuffer();
-    void flush_output_buffer(void *ob, int fd, int *termination_flag);
+    void *create_outputbuffer(int *termination_flag);
+    void flush_output_buffer(void *ob, int fd);
     void delete_outputbuffer(void *);
     void *create_inputbuffer(int *termination_flag);
     void set_inputbuffer_fd(void *, int fd);
@@ -53,4 +53,3 @@ extern "C"
 #endif
 
 #endif /* store_h */
-


### PR DESCRIPTION
reloading naemon while livestatus is still processing a query could lead to a
segfault because livestatus is still accessing internal core memory regions which
may be freed already.
This patch adds a check for the termination flag before each data row. This does not
completly solve the issue since it is theoretically still possible but the timeframe
is reduced from gathering the complete output which might take while to processing a
single data row which is quite fast.

Signed-off-by: Sven Nierlein <sven@nierlein.de>