### PR TITLE
send error response on too large results

### DIFF
--- a/src/Query.cc
+++ b/src/Query.cc
@@ -914,9 +914,7 @@ bool Query::processDataset(void *data)
 {
     if (_output->size() > g_max_response_size) {
         logger(LG_INFO, "Maximum response size of %d bytes exceeded!", g_max_response_size);
-        // _output->setError(RESPONSE_CODE_LIMIT_EXCEEDED, "Maximum response size of %d reached", g_max_response_size);
-        // currently we only log an error into the log file and do
-        // not abort the query. We handle it like Limit:
+        _output->setError(RESPONSE_CODE_LIMIT_EXCEEDED, "Maximum response size of %d reached", g_max_response_size);
         return false;
     }
 


### PR DESCRIPTION
so far livestatus would quietly end a query if it hits the maximum output size without
the client being able to notice. Since it is better to get no data and an error instead
of wrong or incomplete data and not even knowing it we better bail out with an error.

Signed-off-by: Sven Nierlein <sven@nierlein.de>