### PR TITLE
fix E: invalid-license

### DIFF
--- a/naemon-livestatus.spec
+++ b/naemon-livestatus.spec
@@ -2,7 +2,7 @@ Summary: Naemon Livestatus Eventbroker Module
 Name: naemon-livestatus
 Version: 1.1.0
 Release: 0
-License: GPLv2
+License: GPL-2.0-only
 Group: Applications/System
 URL: http://www.naemon.org/
 Packager: Naemon Core Development Team <naemon-dev@monitoring-lists.org>


### PR DESCRIPTION
same issue as in https://github.com/naemon/naemon-core/pull/317

GPLv2 is not a valid license according to rpmlint and https://spdx.org/licenses/