### PR TITLE
add build requirement for centos 8

### DIFF
--- a/naemon-livestatus.spec
+++ b/naemon-livestatus.spec
@@ -14,6 +14,9 @@ BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool
 BuildRequires: gcc-c++
+%if 0%{?el8}
+BuildRequires: gdb-headless
+%endif
 
 
 %description


### PR DESCRIPTION
creating debug packages requires gdb-add-index which is in package gdb-headless. Results in
```
ERROR: GDB index requested, but no gdb-add-index installed
```
otherwise.

Signed-off-by: Sven Nierlein <sven@nierlein.de>