### PR TITLE
Use recursive mutex on downtime/comment table

### DIFF
--- a/src/TableDownComm.cc
+++ b/src/TableDownComm.cc
@@ -40,11 +40,27 @@ TableDownComm::TableDownComm(bool is_downtime)
 {
     int err;
     char errmsg[256] = "unknown error";
-    err = pthread_mutex_init(&_entries_mutex, NULL);
+
+    pthread_mutexattr_t attr;
+    err = pthread_mutexattr_init(&attr);
+    if(err) {
+        strerror_r(err, errmsg, 256);
+        logger(LG_INFO, "Error creating mutex attr: %s (%d)", errmsg, err);
+   }
+
+    err = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    if(err) {
+        strerror_r(err, errmsg, 256);
+        logger(LG_INFO, "Error setting mutex type: %s (%d)", errmsg, err);
+    }
+
+    err = pthread_mutex_init(&_entries_mutex, &attr);
     if(err) {
         strerror_r(err, errmsg, 256);
         logger(LG_INFO, "Error creating mutex: %s (%d)", errmsg, err);
     }
+
+    pthread_mutexattr_destroy(&attr);
 
     if (is_downtime)
         _name = "downtimes";

--- a/tests/features/queries.feature
+++ b/tests/features/queries.feature
@@ -46,3 +46,11 @@ Feature: Queries work as expected
 			|host1|
 			|host2|
 			|host3|
+
+	Scenario: Get comments
+		Given I submit the following external command "ADD_HOST_COMMENT;host1;1;admin;Comment"
+		And I submit the following livestatus query
+			|GET comments|
+			|Columns: host_comments|
+		Then I should see the following livestatus response
+			|1|

--- a/tests/features/step_definitions/naemon_object_config.rb
+++ b/tests/features/step_definitions/naemon_object_config.rb
@@ -13,6 +13,11 @@ And /^I start naemon$/ do
   @naemon.start()
 end
 
+Given(/^I submit the following external command "(.*?)"$/) do |cmd|
+  shell = "/usr/bin/printf \"[%lu] #{cmd}\n\" `date +%s` > #{@naemon.config_dir}/naemon.cmd"
+  `#{shell}`
+end
+
 After do
   @naemon.stop
 end

--- a/tests/features/support/naemon.rb
+++ b/tests/features/support/naemon.rb
@@ -1,5 +1,6 @@
 class Naemon
   attr_accessor :brokers
+  attr_accessor :config_dir
 
   def initialize
     @config_dir = (`mktemp --directory --tmpdir=.`).strip()


### PR DESCRIPTION
The downtime/comment table also contains the related host and service
object, which in turn, contains all the comment/downtimes for the
object. Due to this, when for example doing the following request:
`GET comments\nColumns: host_comments`
we would do a recursive call to `DownCommColumn::output`. This would
lead to a deadlock as the mutex lock is called twice, without unlocking.

To fix this issue we use a recursive mutex, which allows one thread to
run multiple locks on a single mutex.

Also add a simple small testcase.

Signed-off-by: Jacob Hansen <jhansen@op5.com>