### PR TITLE
backport statehist table

### DIFF
--- a/src/Filter.h
+++ b/src/Filter.h
@@ -36,23 +36,27 @@ using namespace std;
 #define HOSTSERVICE_SEPARATOR '|'
 
 class Query;
+class Column;
 
 class Filter
 {
     string _error_message; // Error in constructor
     unsigned _error_code;
+    Column *_column;
 
 protected:
     Query *_query; // needed by TimeOffsetFilter (currently)
     void setError(unsigned code, const char *format, ...);
 
 public:
-    Filter() : _query(0) {}
+    Filter() : _query(0), _column(0) {}
     virtual ~Filter() {}
     string errorMessage() { return _error_message; }
     unsigned errorCode() { return _error_code; }
     bool hasError() { return _error_message != ""; }
     void setQuery(Query *q) { _query = q; }
+    void setColumn(Column *c) { _column = c; }
+    Column *column() { return _column; }
     virtual bool accepts(void *data) = 0;
     virtual void *indexFilter(const char *columnname __attribute__ ((__unused__))) { return 0; }
     virtual void findIntLimits(const char *columnname __attribute__ ((__unused__)), int *lower __attribute__ ((__unused__)), int *upper __attribute__ ((__unused__))) {}

--- a/src/HostServiceState.cc
+++ b/src/HostServiceState.cc
@@ -5,7 +5,7 @@
 // |           | |___| | | |  __/ (__|   <    | |  | | . \            |
 // |            \____|_| |_|\___|\___|_|\_\___|_|  |_|_|\_\           |
 // |                                                                  |
-// | Copyright Mathias Kettner 2012             mk@mathias-kettner.de |
+// | Copyright Mathias Kettner 2014             mk@mathias-kettner.de |
 // +------------------------------------------------------------------+
 //
 // This file is part of Check_MK.
@@ -22,43 +22,45 @@
 // to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 // Boston, MA 02110-1301 USA.
 
-#ifndef tables_h
-#define tables_h
+#include <stdlib.h>
+#include "HostServiceState.h"
 
-#ifndef EXTERN
-#define EXTERN extern
-#endif
+HostServiceState::HostServiceState()
+    : _is_host(false)
+    , _time(0)
+    , _lineno(0)
+    , _from(0)
+    , _until(0)
+    , _duration(0)
+    , _duration_part(0)
+    , _duration_state_UNMONITORED(0)
+    , _duration_part_UNMONITORED(0)
+    , _duration_state_OK(0)
+    , _duration_part_OK(0)
+    , _duration_state_WARNING(0)
+    , _duration_part_WARNING(0)
+    , _duration_state_CRITICAL(0)
+    , _duration_part_CRITICAL(0)
+    , _duration_state_UNKNOWN(0)
+    , _duration_part_UNKNOWN(0)
+    , _host_down(0)
+    , _state(0)
+    , _in_notification_period(0)
+    , _in_service_period(0)
+    , _in_downtime(0)
+    , _in_host_downtime(0)
+    , _is_flapping(0)
+    , _may_no_longer_exist(false)
+    , _has_vanished(false)
+    , _last_known_time(0)
+    , _host(NULL)
+    , _service(NULL)
+    , _log_output(0)
+    , _notification_period(0)
+    , _service_period(0) {}
 
-class TableContacts;
-EXTERN TableContacts      *g_table_contacts;
-class TableCommands;
-EXTERN TableCommands      *g_table_commands;
-class TableHosts;
-EXTERN TableHosts         *g_table_hosts;
-EXTERN TableHosts         *g_table_hostsbygroup;
-class TableServices;
-EXTERN TableServices      *g_table_services;
-EXTERN TableServices      *g_table_servicesbygroup;
-EXTERN TableServices      *g_table_servicesbyhostgroup;
-class TableHostgroups;
-EXTERN TableHostgroups    *g_table_hostgroups;
-class TableServicegroups;
-EXTERN TableServicegroups *g_table_servicegroups;
-class TableDownComm;
-EXTERN TableDownComm      *g_table_downtimes;
-EXTERN TableDownComm      *g_table_comments;
-class TableTimeperiods;
-EXTERN TableTimeperiods   *g_table_timeperiods;
-class TableContactgroups;
-EXTERN TableContactgroups *g_table_contactgroups;
-class TableStatus;
-EXTERN TableStatus        *g_table_status;
-class TableLog;
-EXTERN TableLog           *g_table_log;
-class TableStateHistory;
-EXTERN TableStateHistory  *g_table_statehistory;
-class TableColumns;
-EXTERN TableColumns       *g_table_columns;
-
-#endif // tables_h
-
+HostServiceState::~HostServiceState()
+{
+    if (_log_output != 0)
+        free(_log_output);
+}

--- a/src/HostServiceState.h
+++ b/src/HostServiceState.h
@@ -1,0 +1,93 @@
+// +------------------------------------------------------------------+
+// |             ____ _               _        __  __ _  __           |
+// |            / ___| |__   ___  ___| | __   |  \/  | |/ /           |
+// |           | |   | '_ \ / _ \/ __| |/ /   | |\/| | ' /            |
+// |           | |___| | | |  __/ (__|   <    | |  | | . \            |
+// |            \____|_| |_|\___|\___|_|\_\___|_|  |_|_|\_\           |
+// |                                                                  |
+// | Copyright Mathias Kettner 2014             mk@mathias-kettner.de |
+// +------------------------------------------------------------------+
+//
+// This file is part of Check_MK.
+// The official homepage is at http://mathias-kettner.de/check_mk.
+//
+// check_mk is free software;  you can redistribute it and/or modify it
+// under the  terms of the  GNU General Public License  as published by
+// the Free Software Foundation in version 2.  check_mk is  distributed
+// in the hope that it will be useful, but WITHOUT ANY WARRANTY;  with-
+// out even the implied warranty of  MERCHANTABILITY  or  FITNESS FOR A
+// PARTICULAR PURPOSE. See the  GNU General Public License for more de-
+// ails.  You should have  received  a copy of the  GNU  General Public
+// License along with GNU Make; see the file  COPYING.  If  not,  write
+// to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
+// Boston, MA 02110-1301 USA.
+
+#ifndef HostServiceState_h
+#define HostServiceState_h
+
+#include <time.h>
+#include <string.h>
+#include <nagios.h>
+#include <vector>
+using namespace std;
+
+struct HostServiceState;
+typedef vector<HostServiceState*> HostServices;
+
+typedef void* HostServiceKey;
+
+struct HostServiceState {
+    bool    _is_host;
+    time_t  _time;
+    int     _lineno;
+    time_t  _from;
+    time_t  _until;
+
+    time_t  _duration;
+    double  _duration_part;
+
+    time_t  _duration_state_UNMONITORED;
+    double  _duration_part_UNMONITORED;
+    time_t  _duration_state_OK;
+    double  _duration_part_OK;
+    time_t  _duration_state_WARNING;
+    double  _duration_part_WARNING;
+    time_t  _duration_state_CRITICAL;
+    double  _duration_part_CRITICAL;
+    time_t  _duration_state_UNKNOWN;
+    double  _duration_part_UNKNOWN;
+
+    // State information
+    int     _host_down;      // used if service
+    int     _state;             // -1/0/1/2/3
+    int     _in_notification_period;
+    int     _in_service_period;
+    int     _in_downtime;
+    int     _in_host_downtime;
+    int     _is_flapping;
+
+    // Service information
+    HostServices _services;
+
+    // Absent state handling
+    bool    _may_no_longer_exist;
+    bool    _has_vanished;
+    time_t  _last_known_time;
+
+    const char  *_debug_info;
+
+    // Pointer to dynamically allocated strings (strdup) that live here.
+    // These pointers are 0, if there is no output (e.g. downtime)
+    char        *_log_output;
+    char        *_notification_period;  // may be "": -> no period known, we assume "always"
+    char        *_service_period;  // may be "": -> no period known, we assume "always"
+    host        *_host;
+    service     *_service;
+    const char  *_host_name;            // Fallback if host no longer exists
+    const char  *_service_description;  // Fallback if service no longer exists
+
+    HostServiceState();
+    ~HostServiceState();
+};
+
+#endif // HostServiceState_h

--- a/src/LogCache.cc
+++ b/src/LogCache.cc
@@ -1,0 +1,265 @@
+// +------------------------------------------------------------------+
+// |             ____ _               _        __  __ _  __           |
+// |            / ___| |__   ___  ___| | __   |  \/  | |/ /           |
+// |           | |   | '_ \ / _ \/ __| |/ /   | |\/| | ' /            |
+// |           | |___| | | |  __/ (__|   <    | |  | | . \            |
+// |            \____|_| |_|\___|\___|_|\_\___|_|  |_|_|\_\           |
+// |                                                                  |
+// | Copyright Mathias Kettner 2014             mk@mathias-kettner.de |
+// +------------------------------------------------------------------+
+//
+// This file is part of Check_MK.
+// The official homepage is at http://mathias-kettner.de/check_mk.
+//
+// check_mk is free software;  you can redistribute it and/or modify it
+// under the  terms of the  GNU General Public License  as published by
+// the Free Software Foundation in version 2.  check_mk is  distributed
+// in the hope that it will be useful, but WITHOUT ANY WARRANTY;  with-
+// out even the implied warranty of  MERCHANTABILITY  or  FITNESS FOR A
+// PARTICULAR PURPOSE. See the  GNU General Public License for more de-
+// ails.  You should have  received  a copy of the  GNU  General Public
+// License along with GNU Make; see the file  COPYING.  If  not,  write
+// to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
+// Boston, MA 02110-1301 USA.
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "nagios.h"
+#include "logger.h"
+#include "tables.h"
+#include "auth.h"
+#include "Logfile.h"
+#include "LogEntry.h"
+#include "LogCache.h"
+
+extern time_t last_log_rotation;
+
+
+#define CHECK_MEM_CYCLE 1000 /* Check memory every N'th new message */
+
+// watch naemon' logfile rotation
+extern char *log_archive_path;
+extern char *log_file;
+
+
+int num_cached_log_messages = 0;
+
+LogCache::LogCache(unsigned long max_cached_messages)
+    : _max_cached_messages(max_cached_messages)
+    , _num_at_last_check(0)
+{
+    pthread_mutex_init(&_lock, 0);
+    updateLogfileIndex();
+}
+
+void LogCache::setMaxCachedMessages(unsigned long m)
+{
+    if (m != _max_cached_messages) {
+        logger(LG_INFO, "Logfile cache: Changing max messages to %ld", m);
+        _max_cached_messages = m;
+    }
+}
+
+LogCache::~LogCache()
+{
+    forgetLogfiles();
+    pthread_mutex_destroy(&_lock);
+}
+
+void LogCache::lockLogCache()
+{
+    pthread_mutex_lock(&_lock);
+}
+
+void LogCache::unlockLogCache()
+{
+    pthread_mutex_unlock(&_lock);
+}
+
+bool LogCache::logCachePreChecks()
+{
+    // Do we have any logfiles (should always be the case,
+    // but we don't want to crash...
+    if (_logfiles.size() == 0) {
+        logger(LG_INFO, "Warning: no logfile found, not even %s", log_file);
+        return false;
+    }
+    // Has Nagios rotated logfiles? => Update
+    // our file index. And delete all memorized
+    // log messages.
+    if (last_log_rotation > _last_index_update) {
+        logger(LG_INFO, "Core has rotated logfiles. Rebuilding logfile index");
+        forgetLogfiles();
+        updateLogfileIndex();
+    }
+    return true;
+}
+
+void LogCache::forgetLogfiles()
+{
+    logger(LG_INFO, "Logfile cache: flushing complete cache.");
+    for (_logfiles_t::iterator it = _logfiles.begin();
+            it != _logfiles.end();
+            ++it)
+    {
+        delete it->second;
+    }
+    _logfiles.clear();
+    num_cached_log_messages = 0;
+}
+
+void LogCache::updateLogfileIndex()
+{
+    _last_index_update = time(0);
+    // We need to find all relevant logfiles. This includes
+    // directory.
+    // the current naemon.log and all files in the archive
+    scanLogfile(log_file, true);
+
+    DIR *dir = opendir(log_archive_path);
+
+    if (dir) {
+        char abspath[4096];
+        struct dirent *ent, *result;
+        int len = offsetof(struct dirent, d_name)
+            + pathconf(log_archive_path, _PC_NAME_MAX) + 1;
+        ent = (struct dirent *)malloc(len);
+
+        while (0 == readdir_r(dir, ent, &result) && result != 0)
+        {
+            if (ent->d_name[0] != '.') {
+                snprintf(abspath, sizeof(abspath), "%s/%s", log_archive_path, ent->d_name);
+                scanLogfile(abspath, false);
+            }
+            // ent = result;
+        }
+        free(ent);
+        closedir(dir);
+    }
+    else
+        logger(LG_INFO, "Cannot open log archive '%s'", log_archive_path);
+}
+
+void LogCache::scanLogfile(char *path, bool watch)
+{
+    Logfile *logfile = new Logfile(path, watch);
+    time_t since = logfile->since();
+    if (since) {
+        // make sure that no entry with that 'since' is existing yet.
+        // under normal circumstances this never happens. But the
+        // user might have copied files around.
+        if (_logfiles.find(since) == _logfiles.end())
+            _logfiles.insert(make_pair(since, logfile));
+        else {
+            logger(LG_WARN, "Ignoring duplicate logfile %s", path);
+            delete logfile;
+        }
+    }
+    else
+        delete logfile;
+}
+
+void LogCache::dumpLogfiles()
+{
+    for (_logfiles_t::iterator it = _logfiles.begin();
+            it != _logfiles.end();
+            ++it)
+    {
+        Logfile *log = it->second;
+    }
+}
+
+/* This method is called each time a log message is loaded
+   into memory. If the number of messages loaded in memory
+   is to large, memory will be freed by flushing logfiles
+   and message not needed by the current query.
+
+   The parameters to this method reflect the current query,
+   not the messages that just has been loaded.
+ */
+void LogCache::handleNewMessage(Logfile *logfile, time_t since __attribute__ ((__unused__)), time_t until __attribute__ ((__unused__)), unsigned logclasses)
+{
+    if ( ++num_cached_log_messages <= _max_cached_messages  )
+        return; // current message count still allowed, everything ok
+
+    /* Memory checking an freeing consumes CPU ressources. We save
+       ressources, by avoiding to make the memory check each time
+       a new message is loaded when being in a sitation where no
+       memory can be freed. We do this by suppressing the check when
+       the number of messages loaded into memory has not grown
+       by at least CHECK_MEM_CYCLE messages */
+    if (num_cached_log_messages < _num_at_last_check + CHECK_MEM_CYCLE)
+        return; // Do not check this time
+
+    // [1] Begin by deleting old logfiles
+    // Begin deleting with the oldest logfile available
+    _logfiles_t::iterator it;
+    for (it = _logfiles.begin(); it != _logfiles.end(); ++it)
+    {
+        Logfile *log = it->second;
+        if (log == logfile) {
+            // Do not touch the logfile the Query is currently accessing
+            break;
+        }
+        if (log->numEntries() > 0) {
+            num_cached_log_messages -= log->numEntries();
+            log->flush(); // drop all messages of that file
+            if (num_cached_log_messages <= _max_cached_messages) {
+                // remember the number of log messages in cache when
+                // the last memory-release was done. No further
+                // release-check shall be done until that number changes.
+                _num_at_last_check = num_cached_log_messages;
+                return;
+            }
+        }
+    }
+    // The end of this loop must be reached by 'break'. At least one logfile
+    // must be the current logfile. So now 'it' points to the current logfile.
+    // We save that pointer for later.
+    _logfiles_t::iterator queryit = it;
+
+    // [2] Delete message classes irrelevent to current query
+    // Starting from the current logfile (wo broke out of the
+    // previous loop just when 'it' pointed to that)
+    for (; it != _logfiles.end(); ++it)
+    {
+        Logfile *log = it->second;
+        if (log->numEntries() > 0 && (log->classesRead() & ~logclasses) != 0) {
+            long freed = log->freeMessages(~logclasses); // flush only messages not needed for current query
+            num_cached_log_messages -= freed;
+            if (num_cached_log_messages <= _max_cached_messages) {
+                _num_at_last_check = num_cached_log_messages;
+                return;
+            }
+        }
+    }
+
+    // [3] Flush newest logfiles
+    // If there are still too many messages loaded, continue
+    // flushing logfiles from the oldest to the newest starting
+    // at the file just after (i.e. newer than) the current logfile
+    for (it = ++queryit; it != _logfiles.end(); ++it)
+    {
+        Logfile *log = it->second;
+        if (log->numEntries() > 0) {
+            num_cached_log_messages -= log->numEntries();
+            log->flush();
+            if (num_cached_log_messages <= _max_cached_messages) {
+                _num_at_last_check = num_cached_log_messages;
+                return;
+            }
+        }
+    }
+    _num_at_last_check = num_cached_log_messages;
+    // If we reach this point, no more logfiles can be unloaded,
+    // despite the fact that there are still too many messages
+    // loaded.
+}

--- a/src/LogCache.h
+++ b/src/LogCache.h
@@ -5,7 +5,7 @@
 // |           | |___| | | |  __/ (__|   <    | |  | | . \            |
 // |            \____|_| |_|\___|\___|_|\_\___|_|  |_|_|\_\           |
 // |                                                                  |
-// | Copyright Mathias Kettner 2012             mk@mathias-kettner.de |
+// | Copyright Mathias Kettner 2014             mk@mathias-kettner.de |
 // +------------------------------------------------------------------+
 //
 // This file is part of Check_MK.
@@ -22,43 +22,48 @@
 // to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 // Boston, MA 02110-1301 USA.
 
-#ifndef tables_h
-#define tables_h
+#ifndef LogCache_h
+#define LogCache_h
 
-#ifndef EXTERN
-#define EXTERN extern
-#endif
+#include <map>
+#include <time.h>
+#include "config.h"
+#include "Table.h"
 
-class TableContacts;
-EXTERN TableContacts      *g_table_contacts;
-class TableCommands;
-EXTERN TableCommands      *g_table_commands;
-class TableHosts;
-EXTERN TableHosts         *g_table_hosts;
-EXTERN TableHosts         *g_table_hostsbygroup;
-class TableServices;
-EXTERN TableServices      *g_table_services;
-EXTERN TableServices      *g_table_servicesbygroup;
-EXTERN TableServices      *g_table_servicesbyhostgroup;
-class TableHostgroups;
-EXTERN TableHostgroups    *g_table_hostgroups;
-class TableServicegroups;
-EXTERN TableServicegroups *g_table_servicegroups;
-class TableDownComm;
-EXTERN TableDownComm      *g_table_downtimes;
-EXTERN TableDownComm      *g_table_comments;
-class TableTimeperiods;
-EXTERN TableTimeperiods   *g_table_timeperiods;
-class TableContactgroups;
-EXTERN TableContactgroups *g_table_contactgroups;
-class TableStatus;
-EXTERN TableStatus        *g_table_status;
-class TableLog;
-EXTERN TableLog           *g_table_log;
-class TableStateHistory;
-EXTERN TableStateHistory  *g_table_statehistory;
-class TableColumns;
-EXTERN TableColumns       *g_table_columns;
+class Logfile;
 
-#endif // tables_h
+typedef map<time_t, Logfile *> _logfiles_t;
 
+class LogCache
+{
+    pthread_mutex_t _lock;
+    unsigned long   _max_cached_messages;
+    unsigned long   _num_at_last_check;
+    _logfiles_t     _logfiles;
+
+public:
+    LogCache(unsigned long max_cached_messages);
+    ~LogCache();
+    void setMaxCachedMessages(unsigned long m);
+    time_t _last_index_update;
+
+    const char *name() { return "log"; }
+    const char *prefixname() { return "logs"; }
+    bool isAuthorized(contact *ctc, void *data);
+    void handleNewMessage(Logfile *logfile, time_t since, time_t until, unsigned logclasses);
+    Column *column(const char *colname); // override in order to handle current_
+    _logfiles_t *logfiles() { return &_logfiles; };
+    void forgetLogfiles();
+    void updateLogfileIndex();
+
+    bool logCachePreChecks();
+    void lockLogCache();
+    void unlockLogCache();
+
+private:
+    void scanLogfile(char *path, bool watch);
+    _logfiles_t::iterator findLogfileStartingBefore(time_t);
+    void dumpLogfiles();
+};
+
+#endif // LogCache_h

--- a/src/LogEntry.h
+++ b/src/LogEntry.h
@@ -32,48 +32,75 @@
 #define LOGCLASS_PASSIVECHECK      4 // passive checks
 #define LOGCLASS_COMMAND           5 // external commands
 #define LOGCLASS_STATE             6 // initial or current states
+#define LOGCLASS_TEXT              7 // specific text passages. e.g "logging initial states"
 #define LOGCLASS_INVALID          -1 // never stored
 #define LOGCLASS_ALL          0xffff
 
 #include "nagios.h"
 
+enum LogEntryType {
+    NONE                      = 0,
+    ALERT_HOST                = 1,
+    ALERT_SERVICE             = 2,
+    DOWNTIME_ALERT_HOST       = 3,
+    DOWNTIME_ALERT_SERVICE    = 4,
+    STATE_HOST                = 5,
+    STATE_HOST_INITIAL        = 6,
+    STATE_SERVICE             = 7,
+    STATE_SERVICE_INITIAL     = 8,
+    FLAPPING_HOST             = 9,
+    FLAPPING_SERVICE          = 10,
+    TIMEPERIOD_TRANSITION     = 11,
+    CORE_STARTING             = 12,
+    CORE_STOPPING             = 13,
+    LOG_VERSION               = 14,
+    LOG_INITIAL_STATES        = 15,
+    ACKNOWLEDGE_ALERT_HOST    = 16,
+    ACKNOWLEDGE_ALERT_SERVICE = 17,
+};
+
 struct LogEntry
 {
-    unsigned   _lineno;      // line number in file
-    time_t     _time;
-    unsigned   _logclass;
-    char      *_complete;  // copy of complete unsplit message
-    char      *_options;   // points into _complete after ':'
-    char      *_msg;       // split up with binary zeroes
-    unsigned   _msglen;    // size of _msg
-    char      *_text;      // points into msg
-    char      *_host_name; // points into msg or is 0
-    char      *_svc_desc;  // points into msg or is 0
-    char      *_command_name;
-    char      *_contact_name;
-    int       _state;
-    char      *_state_type;
-    int       _attempt;
-    char      *_check_output;
-    char      *_comment;
+    unsigned     _lineno;      // line number in file
+    time_t       _time;
+    unsigned     _logclass;
+    LogEntryType _type;
+    char        *_complete;  // copy of complete unsplit message
+    char        *_options;   // points into _complete after ':'
+    char        *_msg;       // split up with binary zeroes
+    unsigned     _msglen;    // size of _msg
+    char        *_text;      // points into msg
+    char        *_host_name; // points into msg or is 0
+    char        *_svc_desc;  // points into msg or is 0
+    char        *_command_name;
+    char        *_contact_name;
+    int         _state;
+    char        *_state_type;
+    int         _attempt;
+    char        *_check_output;
+    char        *_comment;
 
-    host      *_host;
-    service   *_service;
-    contact   *_contact;
-    command   *_command;
+    host        *_host;
+    service     *_service;
+    contact     *_contact;
+    command     *_command;
 
     LogEntry(unsigned lineno, char *line);
     ~LogEntry();
+    unsigned updateReferences();
+    static int serviceStateToInt(char *s);
+    static int hostStateToInt(char *s);
 
 private:
     bool handleStatusEntry();
+    bool handleStatusEntryBetter();
     bool handleNotificationEntry();
     bool handlePassiveCheckEntry();
     bool handleExternalCommandEntry();
     bool handleProgrammEntry();
+    bool handleLogversionEntry();
     bool handleInfoEntry();
-    int serviceStateToInt(char *s);
-    int hostStateToInt(char *s);
+    bool handleTextEntry();
 };
 
 #endif // LogEntry_h

--- a/src/Logfile.cc
+++ b/src/Logfile.cc
@@ -22,19 +22,20 @@
 // to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
 // Boston, MA 02110-1301 USA.
 
+#include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <syslog.h>
 #include <string.h>
+
 #include "Logfile.h"
 #include "logger.h"
 #include "LogEntry.h"
 #include "Query.h"
-#include "TableLog.h"
+#include "LogCache.h"
 
-extern int num_cached_log_messages;
-extern int g_debug_level;
+extern unsigned long g_max_lines_per_logfile;
+
 
 Logfile::Logfile(const char *path, bool watch)
   : _path(strdup(path))
@@ -67,33 +68,27 @@ Logfile::Logfile(const char *path, bool watch)
     close(fd);
 }
 
-extern unsigned long g_max_lines_per_logfile;
-
 
 Logfile::~Logfile()
 {
-    free(_path);
     flush();
+    free(_path);
 }
 
 
 void Logfile::flush()
 {
-    for (_entries_t::iterator it = _entries.begin();
-            it != _entries.end();
-            ++it)
-    {
+    for (logfile_entries_t::iterator it = _entries.begin(); it != _entries.end(); ++it)
         delete it->second;
-    }
+
     _entries.clear();
     _logclasses_read = 0;
 }
 
 
-void Logfile::load(TableLog *tablelog, time_t since, time_t until, unsigned logclasses)
+void Logfile::load(LogCache *logcache, time_t since, time_t until, unsigned logclasses)
 {
     unsigned missing_types = logclasses & ~_logclasses_read;
-
     FILE *file = 0;
     // The current logfile has the _watch flag set to true.
     // In that case, if the logfile has grown, we need to
@@ -114,13 +109,13 @@ void Logfile::load(TableLog *tablelog, time_t since, time_t until, unsigned logc
         // have read to the end of the file
         if (_logclasses_read) {
             fsetpos(file, &_read_pos); // continue at previous end
-            loadRange(file, _logclasses_read, tablelog, since, until, logclasses);
+            loadRange(file, _logclasses_read, logcache, since, until, logclasses);
             fgetpos(file, &_read_pos);
         }
         if (missing_types) {
             fseek(file, 0, SEEK_SET);
             _lineno = 0;
-            loadRange(file, missing_types, tablelog, since, until, logclasses);
+            loadRange(file, missing_types, logcache, since, until, logclasses);
             _logclasses_read |= missing_types;
             fgetpos(file, &_read_pos); // remember current end of file
         }
@@ -138,14 +133,14 @@ void Logfile::load(TableLog *tablelog, time_t since, time_t until, unsigned logc
         }
 
         _lineno = 0;
-        loadRange(file, missing_types, tablelog, since, until, logclasses);
+        loadRange(file, missing_types, logcache, since, until, logclasses);
         fclose(file);
         _logclasses_read |= missing_types;
     }
 }
 
 void Logfile::loadRange(FILE *file, unsigned missing_types,
-        TableLog *tablelog, time_t since, time_t until, unsigned logclasses)
+        LogCache *logcache, time_t since, time_t until, unsigned logclasses)
 {
     while (fgets(_linebuffer, MAX_LOGLINE, file))
     {
@@ -155,19 +150,15 @@ void Logfile::loadRange(FILE *file, unsigned missing_types,
         }
         _lineno++;
         if (processLogLine(_lineno, missing_types)) {
-            num_cached_log_messages ++;
-            tablelog->handleNewMessage(this, since, until, logclasses); // memory management
+            logcache->handleNewMessage(this, since, until, logclasses); // memory management
         }
     }
 }
 
-
 long Logfile::freeMessages(unsigned logclasses)
 {
     long freed = 0;
-    for (_entries_t::iterator it = _entries.begin();
-            it != _entries.end();
-            ++it)
+    for (logfile_entries_t::iterator it = _entries.begin(); it != _entries.end(); ++it)
     {
         LogEntry *entry = it->second;
         if ((1 << entry->_logclass) & logclasses)
@@ -181,8 +172,7 @@ long Logfile::freeMessages(unsigned logclasses)
     return freed;
 }
 
-
-bool Logfile::processLogLine(uint32_t lineno, unsigned logclasses)
+inline bool Logfile::processLogLine(uint32_t lineno, unsigned logclasses)
 {
     LogEntry *entry = new LogEntry(lineno, _linebuffer);
     // ignored invalid lines
@@ -207,12 +197,17 @@ bool Logfile::processLogLine(uint32_t lineno, unsigned logclasses)
     }
 }
 
-
-bool Logfile::answerQuery(Query *query, TableLog *tablelog, time_t since, time_t until, unsigned logclasses)
+logfile_entries_t* Logfile::getEntriesFromQuery(Query *query, LogCache *logcache, time_t since, time_t until, unsigned logclasses)
 {
-    load(tablelog, since, until, logclasses); // make sure all messages are present
+    load(logcache, since, until, logclasses); // make sure all messages are present
+    return &_entries;
+}
+
+bool Logfile::answerQuery(Query *query, LogCache *logcache, time_t since, time_t until, unsigned logclasses)
+{
+    load(logcache, since, until, logclasses); // make sure all messages are present
     uint64_t sincekey = makeKey(since, 0);
-    _entries_t::iterator it = _entries.lower_bound(sincekey);
+    logfile_entries_t::iterator it = _entries.lower_bound(sincekey);
     while (it != _entries.end())
     {
         LogEntry *entry = it->second;
@@ -225,11 +220,11 @@ bool Logfile::answerQuery(Query *query, TableLog *tablelog, time_t since, time_t
     return true;
 }
 
-bool Logfile::answerQueryReverse(Query *query, TableLog *tablelog, time_t since, time_t until, unsigned logclasses)
+bool Logfile::answerQueryReverse(Query *query, LogCache *logcache, time_t since, time_t until, unsigned logclasses)
 {
-    load(tablelog, since, until, logclasses); // make sure all messages are present
+    load(logcache, since, until, logclasses); // make sure all messages are present
     uint64_t untilkey = makeKey(until, 999999999);
-    _entries_t::iterator it = _entries.upper_bound(untilkey);
+    logfile_entries_t::iterator it = _entries.upper_bound(untilkey);
     while (it != _entries.begin())
     {
         --it;
@@ -247,3 +242,52 @@ uint64_t Logfile::makeKey(time_t t, unsigned lineno)
     return (uint64_t)((uint64_t)t << 32) | (uint64_t)lineno;
 }
 
+
+// Read complete file into newly allocated buffer. Returns a pointer
+// to a malloced buffer, that the caller must free (or 0, in case of
+// an error). The buffer is 2 bytes larger then the file. One byte
+// at the beginning and at the end of the buffer are '\0'.
+char *Logfile::readIntoBuffer(int *size)
+{
+    int fd = open(_path, O_RDONLY);
+    if (fd < 0) {
+        logger(LG_WARN, "Cannot open %s for reading: %s", _path, strerror(errno));
+        return 0;
+    }
+
+    off_t o = lseek(fd, 0, SEEK_END);
+    if (o == -1) {
+        logger(LG_WARN, "Cannot seek to end of %s: %s", _path, strerror(errno));
+        close(fd);
+        return 0;
+    }
+
+    *size = o;
+    lseek(fd, 0, SEEK_SET);
+
+    char *buffer = (char *)malloc(*size + 2); // add space for binary 0 at beginning and end
+    if (!buffer) {
+        logger(LG_WARN, "Cannot malloc buffer for reading %s: %s", _path, strerror(errno));
+        close(fd);
+        return 0;
+    }
+
+    int r = read(fd, buffer + 1, *size);
+    if (r < 0) {
+        logger(LG_WARN, "Cannot read %d bytes from %s: %s", *size, _path, strerror(errno));
+        free(buffer);
+        close(fd);
+        return 0;
+    }
+    else if (r != *size) {
+        logger(LG_WARN, "Read only %d out of %d bytes from %s", r, *size, _path);
+        free(buffer);
+        close(fd);
+        return 0;
+    }
+    buffer[0]       = 0;
+    buffer[*size+1] = 0; // zero-terminate
+
+    close(fd);
+    return buffer;
+}

--- a/src/Logfile.h
+++ b/src/Logfile.h
@@ -36,37 +36,46 @@ using namespace std;
 
 class LogEntry;
 class Query;
-class TableLog;
+class LogCache;
+
+typedef map<uint64_t, LogEntry *> logfile_entries_t; // key is time_t . lineno
 
 class Logfile
 {
+private:
     char      *_path;
     time_t     _since;         // time of first entry
     bool       _watch;         // true only for current logfile
     ino_t      _inode;         // needed to detect switching
     fpos_t     _read_pos;      // read until this position
     uint32_t   _lineno;        // read until this line
-    unsigned   _logclasses_read; // only these types have been read
-    typedef map<uint64_t, LogEntry *> _entries_t; // key is time_t . lineno
-    _entries_t _entries;
+
+    logfile_entries_t  _entries;
     char       _linebuffer[MAX_LOGLINE];
+
 
 public:
     Logfile(const char *path, bool watch);
     ~Logfile();
 
     char *path() { return _path; }
-    void load(TableLog *tablelog, time_t since, time_t until, unsigned logclasses);
+    char *readIntoBuffer(int *size);
+    void load(LogCache *LogCache, time_t since, time_t until, unsigned logclasses);
     void flush();
     time_t since() { return _since; }
     unsigned classesRead() { return _logclasses_read; }
     long numEntries() { return _entries.size(); }
-    bool answerQuery(Query *query, TableLog *tl, time_t since, time_t until, unsigned);
-    bool answerQueryReverse(Query *query, TableLog *tl, time_t since, time_t until, unsigned);
+    logfile_entries_t* getEntriesFromQuery(Query *query, LogCache *lc, time_t since, time_t until, unsigned);
+    bool answerQuery(Query *query, LogCache *lc, time_t since, time_t until, unsigned);
+    bool answerQueryReverse(Query *query, LogCache *lc, time_t since, time_t until, unsigned);
+
     long freeMessages(unsigned logclasses);
 
+    unsigned   _logclasses_read; // only these types have been read
+
+
 private:
-    void loadRange(FILE *file, unsigned missing_types, TableLog *, 
+    void loadRange(FILE *file, unsigned missing_types, LogCache *,
                    time_t since, time_t until, unsigned logclasses);
     bool processLogLine(uint32_t, unsigned);
     uint64_t makeKey(time_t, unsigned);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,7 @@ livestatus_la_SOURCES = \
 	StringColumn.cc StringColumnFilter.cc strutil.cc Table.cc TableColumns.cc \
 	HostSpecialDoubleColumn.cc TableCommands.cc TableContacts.cc TableDownComm.cc TableHostgroups.cc \
 	ServiceSpecialDoubleColumn.cc TableHosts.cc TableServicegroups.cc TableServices.cc TableStatus.cc  \
-	LogEntry.cc Logfile.cc TableLog.cc TableTimeperiods.cc TableContactgroups.cc \
+	LogEntry.cc LogCache.cc Logfile.cc TableStateHistory.cc TableLog.cc TableTimeperiods.cc TableContactgroups.cc \
 	ContactgroupsMemberColumn.cc OffsetStringMacroColumn.cc OffsetStringServiceMacroColumn.cc \
 	OffsetStringHostMacroColumn.cc StatsColumn.cc IntAggregator.cc CountAggregator.cc \
 	DoubleAggregator.cc AttributelistColumn.cc AttributelistFilter.cc \
@@ -55,7 +55,7 @@ livestatus_la_SOURCES = \
 	TimeperiodExclusionColumn.cc TimeperiodDaysColumn.cc TimeperiodExceptionsColumn.cc pnp4nagios.cc \
 	HostlistDependencyColumn.cc HostlistDependencyColumnFilter.cc \
 	ServicelistDependencyColumn.cc ServicelistDependencyColumnFilter.cc \
-	ContactgroupsColumn.cc RowSortedSet.cc opids.cc auth.cc
+	ContactgroupsColumn.cc RowSortedSet.cc HostServiceState.cc opids.cc auth.cc
 
 if HAVE_DIET
 	diet -v $(CC) -x c -Wno-deprecated-declarations $(CFLAGS) $(LDFLAGS) -I.. -s -o $@ $^

--- a/src/OffsetStringColumn.cc
+++ b/src/OffsetStringColumn.cc
@@ -41,4 +41,3 @@ const char *OffsetStringColumn::getValue(void *data)
     else
         return (char *)"";
 }
-

--- a/src/Query.h
+++ b/src/Query.h
@@ -105,11 +105,13 @@ public:
     Query(InputBuffer *, OutputBuffer *out, Table *);
     ~Query();
     bool processDataset(void *);
+    bool timelimitReached();
     void start();
     void finish();
     void setDefaultColumns(const char *);
     void addColumn(Column *column);
     void setShowColumnHeaders(bool x) { _show_column_headers = x; }
+    void setError(int error_code, const char * msg);
     bool hasNoColumns();
     contact *authUser() { return _auth_user; }
     void outputDatasetBegin();
@@ -121,8 +123,11 @@ public:
     void outputUnsignedLong(unsigned long);
     void outputCounter(counter_t);
     void outputDouble(double);
+    void outputNull();
+    void outputAsciiEscape(char value);
     void outputUnicodeEscape(unsigned value);
     void outputString(const char *);
+    void outputBlob(const char *buffer, int size);
     void outputHostService(const char *, const char *);
     void outputBeginList();
     void outputListSeparator();
@@ -139,6 +144,7 @@ public:
     void findIntLimits(const char *columnname, int *lower, int *upper);
     void optimizeBitmask(const char *columnname, uint32_t *bitmask);
     int timezoneOffset() { return _timezone_offset; }
+    AndingFilter *filter() { return &_filter; }
 
 private:
     bool doStats();

--- a/src/Store.cc
+++ b/src/Store.cc
@@ -43,14 +43,14 @@ extern unsigned long g_max_cached_messages;
 extern char *qh_socket_path;
 
 Store::Store()
-  :_table_hosts(false)
+  : _log_cache(g_max_cached_messages)
+  , _table_hosts(false)
   , _table_hostsbygroup(true)
   , _table_services(false, false)
   , _table_servicesbygroup(true, false)
   , _table_servicesbyhostgroup(false, true)
   , _table_downtimes(true)
   , _table_comments(false)
-  , _table_log(g_max_cached_messages)
 {
     _tables.insert(make_pair("hosts", &_table_hosts));
     _tables.insert(make_pair("hostsbygroup", &_table_hostsbygroup));
@@ -65,6 +65,7 @@ Store::Store()
     _tables.insert(make_pair("comments", &_table_comments));
     _tables.insert(make_pair("status", &_table_status));
     _tables.insert(make_pair("log", &_table_log));
+    _tables.insert(make_pair("statehist", &_table_statehistory));
     _tables.insert(make_pair("timeperiods", &_table_timeperiods));
     _tables.insert(make_pair("contactgroups", &_table_contactgroups));
     _tables.insert(make_pair("columns", &_table_columns));
@@ -83,6 +84,7 @@ Store::Store()
     g_table_timeperiods = &_table_timeperiods;
     g_table_contactgroups = &_table_contactgroups;
     g_table_log = &_table_log;
+    g_table_statehistory = &_table_statehistory;
     g_table_columns = &_table_columns;
 
     for (_tables_t::iterator it = _tables.begin();

--- a/src/Store.h
+++ b/src/Store.h
@@ -38,12 +38,15 @@
 #include "TableDownComm.h"
 #include "TableStatus.h"
 #include "TableLog.h"
+#include "TableStateHistory.h"
 #include "TableColumns.h"
 #include "OutputBuffer.h"
 #include "InputBuffer.h"
+#include "LogCache.h"
 
 class Store
 {
+    LogCache           _log_cache;
     TableContacts      _table_contacts;
     TableCommands      _table_commands;
     TableHostgroups    _table_hostgroups;
@@ -59,6 +62,7 @@ class Store
     TableDownComm      _table_comments;
     TableStatus        _table_status;
     TableLog           _table_log;
+    TableStateHistory  _table_statehistory;
     TableColumns       _table_columns;
 
     typedef map<string, Table *> _tables_t;
@@ -66,6 +70,7 @@ class Store
 
 public:
     Store();
+    LogCache* logCache(){ return &_log_cache; };
     void registerHostgroup(hostgroup *);
     void registerComment(nebstruct_comment_data *);
     void registerDowntime(nebstruct_downtime_data *);

--- a/src/StringColumn.h
+++ b/src/StringColumn.h
@@ -45,4 +45,3 @@ public:
 };
 
 #endif // StringColumn_h
-

--- a/src/TableLog.cc
+++ b/src/TableLog.cc
@@ -27,8 +27,6 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <stddef.h>
-#include <stdarg.h>
-#include <syslog.h>
 
 #include "nagios.h"
 #include "logger.h"
@@ -45,127 +43,73 @@
 #include "TableCommands.h"
 #include "TableContacts.h"
 #include "auth.h"
+#include "Store.h"
 
 #define CHECK_MEM_CYCLE 1000 /* Check memory every N'th new message */
 
-// watch nagios' logfile rotation
-extern time_t last_log_rotation;
-extern int g_debug_level;
+extern Store *g_store;
 
-int num_cached_log_messages = 0;
-
-// Debugging logging is hard if debug messages are logged themselves...
-void debug(const char *loginfo, ...)
+TableLog::TableLog()
 {
-    if (g_debug_level < 2)
-        return;
-
-    FILE *x = fopen("/tmp/livestatus.log", "a+");
-    va_list ap;
-    va_start(ap, loginfo);
-    vfprintf(x, loginfo, ap);
-    fputc('\n', x);
-    va_end(ap);
-    fclose(x);
+    addColumns(this, "", -1);
 }
 
-
-TableLog::TableLog(unsigned long max_cached_messages)
-  : _num_cached_messages(0)
-  , _max_cached_messages(max_cached_messages)
-  , _num_at_last_check(0)
+void TableLog::addColumns(Table *table, string prefix, int indirect_offset, bool add_host, bool add_services)
 {
-    pthread_mutex_init(&_lock, 0);
-
     LogEntry *ref = 0;
-    addColumn(new OffsetTimeColumn("time",
-                "Time of the log event (UNIX timestamp)", (char *)&(ref->_time) - (char *)ref, -1));
-    addColumn(new OffsetIntColumn("lineno",
-                "The number of the line in the log file", (char *)&(ref->_lineno) - (char *)ref, -1));
-    addColumn(new OffsetIntColumn("class",
-                "The class of the message as integer (0:info, 1:alert, 2:program, 3:notification, 4:passive, 5:command, 6:state)", (char *)&(ref->_logclass) - (char *)ref, -1));
-
-    addColumn(new OffsetStringColumn("message",
-                "The complete message line including the timestamp", (char *)&(ref->_complete) - (char *)ref, -1));
-    addColumn(new OffsetStringColumn("type",
-                "The type of the message (text before the colon), the message itself for info messages", (char *)&(ref->_text) - (char *)ref, -1));
-    addColumn(new OffsetStringColumn("options",
-                "The part of the message after the ':'", (char *)&(ref->_options) - (char *)ref, -1));
-    addColumn(new OffsetStringColumn("comment",
-                "A comment field used in various message types", (char *)&(ref->_comment) - (char *)ref, -1));
-    addColumn(new OffsetStringColumn("plugin_output",
-                "The output of the check, if any is associated with the message", (char *)&(ref->_check_output) - (char *)ref, -1));
-    addColumn(new OffsetIntColumn("state",
-                "The state of the host or service in question", (char *)&(ref->_state) - (char *)ref, -1));
-    addColumn(new OffsetStringColumn("state_type",
-                "The type of the state (varies on different log classes)", (char *)&(ref->_state_type) - (char *)ref, -1));
-    addColumn(new OffsetIntColumn("attempt",
-                "The number of the check attempt", (char *)&(ref->_attempt) - (char *)ref, -1));
-    addColumn(new OffsetStringColumn("service_description",
-                "The description of the service log entry is about (might be empty)",
-                (char *)&(ref->_svc_desc) - (char *)ref, -1));
-    addColumn(new OffsetStringColumn("host_name",
-                "The name of the host the log entry is about (might be empty)",
-                (char *)&(ref->_host_name) - (char *)ref, -1));
-    addColumn(new OffsetStringColumn("contact_name",
-                "The name of the contact the log entry is about (might be empty)",
-                (char *)&(ref->_contact_name) - (char *)ref, -1));
-    addColumn(new OffsetStringColumn("command_name",
-                "The name of the command of the log entry (e.g. for notifications)",
-                (char *)&(ref->_command_name) - (char *)ref, -1));
+    table->addColumn(new OffsetTimeColumn(prefix + "time",
+            "Time of the log event (UNIX timestamp)", (char *)&(ref->_time) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetIntColumn(prefix + "lineno",
+            "The number of the line in the log file", (char *)&(ref->_lineno) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetIntColumn(prefix + "class",
+            "The class of the message as integer (0:info, 1:state, 2:program, 3:notification, 4:passive, 5:command)", (char *)&(ref->_logclass) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "message",
+            "The complete message line including the timestamp", (char *)&(ref->_complete) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "type",
+            "The type of the message (text before the colon), the message itself for info messages", (char *)&(ref->_text) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "options",
+            "The part of the message after the ':'", (char *)&(ref->_options) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "comment",
+            "A comment field used in various message types", (char *)&(ref->_comment) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "plugin_output",
+            "The output of the check, if any is associated with the message", (char *)&(ref->_check_output) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetIntColumn(prefix + "state",
+            "The state of the host or service in question", (char *)&(ref->_state) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "state_type",
+            "The type of the state (varies on different log classes)", (char *)&(ref->_state_type) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetIntColumn(prefix + "attempt",
+            "The number of the check attempt", (char *)&(ref->_attempt) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "service_description",
+            "The description of the service log entry is about (might be empty)",
+            (char *)&(ref->_svc_desc) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "host_name",
+            "The name of the host the log entry is about (might be empty)",
+            (char *)&(ref->_host_name) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "contact_name",
+            "The name of the contact the log entry is about (might be empty)",
+            (char *)&(ref->_contact_name) - (char *)ref, indirect_offset));
+    table->addColumn(new OffsetStringColumn(prefix + "command_name",
+            "The name of the command of the log entry (e.g. for notifications)",
+            (char *)&(ref->_command_name) - (char *)ref, indirect_offset));
 
     // join host and service tables
-    g_table_hosts->addColumns(this, "current_host_",    (char *)&(ref->_host)    - (char *)ref);
-    g_table_services->addColumns(this, "current_service_", (char *)&(ref->_service) - (char *)ref, false /* no hosts table */);
-    g_table_contacts->addColumns(this, "current_contact_", (char *)&(ref->_contact) - (char *)ref);
-    g_table_commands->addColumns(this, "current_command_", (char *)&(ref->_command) - (char *)ref);
-
-    updateLogfileIndex();
+    if (add_host)
+        g_table_hosts->addColumns(table, "current_host_",    (char *)&(ref->_host)    - (char *)ref);
+    if (add_services)
+        g_table_services->addColumns(table, "current_service_", (char *)&(ref->_service) - (char *)ref, false /* no hosts table */);
+    g_table_contacts->addColumns(table, "current_contact_", (char *)&(ref->_contact) - (char *)ref);
+    g_table_commands->addColumns(table, "current_command_", (char *)&(ref->_command) - (char *)ref);
 }
 
 
 TableLog::~TableLog()
 {
-    forgetLogfiles();
-    pthread_mutex_destroy(&_lock);
 }
-
-
-void TableLog::forgetLogfiles()
-{
-    for (_logfiles_t::iterator it = _logfiles.begin();
-            it != _logfiles.end();
-            ++it)
-    {
-        delete it->second;
-    }
-    _logfiles.clear();
-    _num_cached_messages = 0;
-}
-
 
 void TableLog::answerQuery(Query *query)
 {
-    // since logfiles are loaded on demand, we need
-    // to lock out concurrent threads.
-    pthread_mutex_lock(&_lock);
-
-    // Do we have any logfiles (should always be the case,
-    // but we don't want to crash...
-    if (_logfiles.size() == 0) {
-        pthread_mutex_unlock(&_lock);
-        logger(LOG_INFO, "Warning: no logfile found, not even nagios.log");
-        return;
-    }
-
-    // Has Nagios rotated logfiles? => Update
-    // our file index. And delete all memorized
-    // log messages.
-    if (last_log_rotation > _last_index_update) {
-        logger(LG_INFO, "Nagios has rotated logfiles. Rebuilding logfile index");
-        forgetLogfiles();
-        updateLogfileIndex();
-    }
+    g_store->logCache()->lockLogCache();
+    g_store->logCache()->logCachePreChecks();
 
     int since = 0;
     int until = time(0) + 1;
@@ -181,10 +125,9 @@ void TableLog::answerQuery(Query *query)
     uint32_t classmask = LOGCLASS_ALL;
     query->optimizeBitmask("class", &classmask);
     if (classmask == 0) {
-        pthread_mutex_unlock(&_lock);
+        g_store->logCache()->unlockLogCache();
         return;
     }
-
 
     /* This code start with the oldest log entries. I'm going
        to change this and start with the newest. That way,
@@ -192,192 +135,30 @@ void TableLog::answerQuery(Query *query)
 
     /* NEW CODE - NEWEST FIRST */
     _logfiles_t::iterator it;
-    it = _logfiles.end(); // it now points beyond last log file
+    it = g_store->logCache()->logfiles()->end(); // it now points beyond last log file
     --it; // switch to last logfile (we have at least one)
 
     // Now find newest log where 'until' is contained. The problem
     // here: For each logfile we only know the time of the *first* entry,
     // not that of the last.
-    while (it != _logfiles.begin() && it->first > until) // while logfiles are too new...
+    while (it != g_store->logCache()->logfiles()->begin() && it->first > until) // while logfiles are too new...
         --it; // go back in history
-    if (it->first > until)  { // all logfiles are too new
-        pthread_mutex_unlock(&_lock);
+    if (it->first > until) { // all logfiles are too new
+        g_store->logCache()->unlockLogCache();
         return;
     }
 
     while (true) {
         Logfile *log = it->second;
-        debug("Query is now at logfile %s, needing classes 0x%x", log->path(), classmask);
-        if (!log->answerQueryReverse(query, this, since, until, classmask))
+        if (!log->answerQueryReverse(query, g_store->logCache(), since, until, classmask))
             break; // end of time range found
-        if (it == _logfiles.begin())
+        if (it == g_store->logCache()->logfiles()->begin())
             break; // this was the oldest one
         --it;
     }
-
-    // dumpLogfiles();
-    pthread_mutex_unlock(&_lock);
+    g_store->logCache()->unlockLogCache();
 }
 
-
-extern char *log_file;
-extern char *log_archive_path;
-
-void TableLog::updateLogfileIndex()
-{
-    _last_index_update = time(0);
-
-    // We need to find all relevant logfiles. This includes
-    // the current nagios.log and all files in the archive
-    // directory.
-    scanLogfile(log_file, true);
-    DIR *dir = opendir(log_archive_path);
-    if (dir) {
-        char abspath[4096];
-        struct dirent *ent, *result;
-        int len = offsetof(struct dirent, d_name)
-            + pathconf(log_archive_path, _PC_NAME_MAX) + 1;
-        ent = (struct dirent *)malloc(len);
-        while (0 == readdir_r(dir, ent, &result) && result != 0)
-        {
-            if (ent->d_name[0] != '.') {
-                snprintf(abspath, sizeof(abspath), "%s/%s", log_archive_path, ent->d_name);
-                scanLogfile(abspath, false);
-            }
-            // ent = result;
-        }
-        free(ent);
-        closedir(dir);
-    }
-    else
-        logger(LG_INFO, "Cannot open log archive '%s'", log_archive_path);
-}
-
-void TableLog::scanLogfile(char *path, bool watch)
-{
-    Logfile *logfile = new Logfile(path, watch);
-    time_t since = logfile->since();
-    if (since) {
-        // make sure that no entry with that 'since' is existing yet.
-        // under normal circumstances this never happens. But the
-        // user might have copied files around.
-        if (_logfiles.find(since) == _logfiles.end())
-            _logfiles.insert(make_pair(since, logfile));
-        else {
-            logger(LG_WARN, "Ignoring duplicate logfile %s", path);
-            delete logfile;
-        }
-    }
-    else
-        delete logfile;
-}
-
-void TableLog::dumpLogfiles()
-{
-    for (_logfiles_t::iterator it = _logfiles.begin();
-            it != _logfiles.end();
-            ++it)
-    {
-        Logfile *log = it->second;
-        debug("LOG %s from %d, %u messages, classes: 0x%04x", log->path(), log->since(), log->numEntries(), log->classesRead());
-    }
-}
-
-/* This method is called each time a log message is loaded
-   into memory. If the number of messages loaded in memory
-   is to large, memory will be freed by flushing logfiles
-   and message not needed by the current query.
-
-   The parameters to this method reflect the current query,
-   not the messages that just has been loaded.
- */
-void TableLog::handleNewMessage(Logfile *logfile, time_t since __attribute__ ((__unused__)), time_t until __attribute__ ((__unused__)), unsigned logclasses)
-{
-    if (++_num_cached_messages <= _max_cached_messages)
-        return; // current message count still allowed, everything ok
-
-    /* Memory checking an freeing consumes CPU ressources. We save
-       ressources, by avoiding to make the memory check each time
-       a new message is loaded when being in a sitation where no
-       memory can be freed. We do this by suppressing the check when
-       the number of messages loaded into memory has not grown
-       by at least CHECK_MEM_CYCLE messages */
-    if (_num_cached_messages < _num_at_last_check + CHECK_MEM_CYCLE)
-        return; // Do not check this time
-
-    // [1] Begin by deleting old logfiles
-    // Begin deleting with the oldest logfile available
-    _logfiles_t::iterator it;
-    for (it = _logfiles.begin(); it != _logfiles.end(); ++it)
-    {
-        Logfile *log = it->second;
-        ///if (g_debug_level > 2)
-        //    debug("Logfile %s (%s, %d entries)", log->path(), log == logfile ? "current" : "other", log->numEntries());
-        if (log == logfile) {
-            // Do not touch the logfile the Query is currently accessing
-            // and
-            break;
-        }
-        if (log->numEntries() > 0) {
-            _num_cached_messages -= log->numEntries();
-            log->flush(); // drop all messages of that file
-            if (_num_cached_messages <= _max_cached_messages) {
-                // remember the number of log messages in cache when
-                // the last memory-release was done. No further
-                // release-check shall be done until that number changes.
-                _num_at_last_check = _num_cached_messages;
-                return;
-            }
-        }
-    }
-    // The end of this loop must be reached by 'break'. At least one logfile
-    // must be the current logfile. So now 'it' points to the current logfile.
-    // We save that pointer for later.
-    _logfiles_t::iterator queryit = it;
-
-    // [2] Delete message classes irrelevent to current query
-    // Starting from the current logfile (wo broke out of the
-    // previous loop just when 'it' pointed to that)
-    for (; it != _logfiles.end(); ++it)
-    {
-        Logfile *log = it->second;
-        if (log->numEntries() > 0 && (log->classesRead() & ~logclasses) != 0) {
-            if (g_debug_level > 2)
-                debug("Freeing classes 0x%02x of file %s", ~logclasses, log->path());
-            long freed = log->freeMessages(~logclasses); // flush only messages not needed for current query
-            _num_cached_messages -= freed;
-            if (_num_cached_messages <= _max_cached_messages) {
-                _num_at_last_check = _num_cached_messages;
-                return;
-            }
-        }
-    }
-
-    // [3] Flush newest logfiles
-    // If there are still too many messages loaded, continue
-    // flushing logfiles from the oldest to the newest starting
-    // at the file just after (i.e. newer than) the current logfile
-    for (it = ++queryit; it != _logfiles.end(); ++it)
-    {
-        Logfile *log = it->second;
-
-        if (log->numEntries() > 0) {
-            _num_cached_messages -= log->numEntries();
-            log->flush();
-            if (_num_cached_messages <= _max_cached_messages) {
-                _num_at_last_check = _num_cached_messages;
-                return;
-            }
-        }
-    }
-    _num_at_last_check = _num_cached_messages;
-    // If we reach this point, no more logfiles can be unloaded,
-    // despite the fact that there are still too many messages
-    // loaded.
-    if (g_debug_level > 2)
-        debug("Cannot unload more messages. Still %d loaded (max is %d)",
-                _num_cached_messages, _max_cached_messages);
-}
 
 bool TableLog::isAuthorized(contact *ctc, void *data)
 {
@@ -390,9 +171,9 @@ bool TableLog::isAuthorized(contact *ctc, void *data)
     // suppress entries for messages that belong to
     // hosts that do not exist anymore.
     else if (entry->_logclass == LOGCLASS_ALERT
-        || entry->_logclass == LOGCLASS_NOTIFICATION
-        || entry->_logclass == LOGCLASS_PASSIVECHECK
-        || entry->_logclass == LOGCLASS_STATE)
+            || entry->_logclass == LOGCLASS_NOTIFICATION
+            || entry->_logclass == LOGCLASS_PASSIVECHECK
+            || entry->_logclass == LOGCLASS_STATE)
         return false;
     else
         return true;

--- a/src/TableStateHistory.cc
+++ b/src/TableStateHistory.cc
@@ -1,0 +1,805 @@
+// +------------------------------------------------------------------+
+// |             ____ _               _        __  __ _  __           |
+// |            / ___| |__   ___  ___| | __   |  \/  | |/ /           |
+// |           | |   | '_ \ / _ \/ __| |/ /   | |\/| | ' /            |
+// |           | |___| | | |  __/ (__|   <    | |  | | . \            |
+// |            \____|_| |_|\___|\___|_|\_\___|_|  |_|_|\_\           |
+// |                                                                  |
+// | Copyright Mathias Kettner 2014             mk@mathias-kettner.de |
+// +------------------------------------------------------------------+
+//
+// This file is part of Check_MK.
+// The official homepage is at http://mathias-kettner.de/check_mk.
+//
+// check_mk is free software;  you can redistribute it and/or modify it
+// under the  terms of the  GNU General Public License  as published by
+// the Free Software Foundation in version 2.  check_mk is  distributed
+// in the hope that it will be useful, but WITHOUT ANY WARRANTY;  with-
+// out even the implied warranty of  MERCHANTABILITY  or  FITNESS FOR A
+// PARTICULAR PURPOSE. See the  GNU General Public License for more de-
+// ails.  You should have  received  a copy of the  GNU  General Public
+// License along with GNU Make; see the file  COPYING.  If  not,  write
+// to the Free Software Foundation, Inc., 51 Franklin St,  Fifth Floor,
+// Boston, MA 02110-1301 USA.
+
+#include <time.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <list>
+
+#include "nagios.h"
+#include "logger.h"
+#include "OffsetIntColumn.h"
+#include "OffsetTimeColumn.h"
+#include "OffsetStringColumn.h"
+#include "OffsetDoubleColumn.h"
+#include "Query.h"
+#include "tables.h"
+#include "auth.h"
+#include "Store.h"
+#include "LogEntry.h"
+#include "TableStateHistory.h"
+#include "HostServiceState.h"
+
+int g_disable_statehist_filtering = 0;
+
+
+
+extern Store *g_store;
+
+const char *getCustomVariable(customvariablesmember *cvm, const char *name)
+{
+    while (cvm) {
+        if (!strcmp(cvm->variable_name, name))
+            return cvm->variable_value;
+        cvm = cvm->next;
+    }
+    return "";
+}
+
+TableStateHistory::TableStateHistory()
+{
+    TableStateHistory::addColumns(this);
+}
+
+void TableStateHistory::addColumns(Table *table)
+{
+    HostServiceState *ref = 0;
+    table->addColumn(new OffsetTimeColumn("time",
+            "Time of the log event (seconds since 1/1/1970)", (char *)&(ref->_time) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("lineno",
+            "The number of the line in the log file", (char *)&(ref->_lineno) - (char *)ref, -1));
+    table->addColumn(new OffsetTimeColumn("from",
+            "Start time of state (seconds since 1/1/1970)", (char *)&(ref->_from) - (char *)ref, -1));
+    table->addColumn(new OffsetTimeColumn("until",
+            "End time of state (seconds since 1/1/1970)", (char *)&(ref->_until) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("duration",
+            "Duration of state (until - from)", (char *)&(ref->_duration) - (char *)ref, -1));
+    table->addColumn(new OffsetDoubleColumn("duration_part",
+            "Duration part in regard to the query timeframe", (char *)(&ref->_duration_part) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("state",
+            "The state of the host or service in question - OK(0) / WARNING(1) / CRITICAL(2) / UNKNOWN(3) / UNMONITORED(-1)", (char *)&(ref->_state) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("host_down",
+            "Shows if the host of this service is down", (char *)&(ref->_host_down) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("in_downtime",
+            "Shows if the host or service is in downtime", (char *)&(ref->_in_downtime) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("in_host_downtime",
+            "Shows if the host of this service is in downtime", (char *)&(ref->_in_host_downtime) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("is_flapping",
+            "Shows if the host or service is flapping", (char *)&(ref->_is_flapping) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("in_notification_period",
+            "Shows if the host or service is within its notification period", (char *)&(ref->_in_notification_period) - (char *)ref, -1));
+    table->addColumn(new OffsetStringColumn("notification_period",
+            "The notification period of the host or service in question", (char *)&(ref->_notification_period) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("in_service_period",
+            "Shows if the host or service is within its service period", (char *)&(ref->_in_service_period) - (char *)ref, -1));
+    table->addColumn(new OffsetStringColumn("service_period",
+            "The service period of the host or service in question", (char *)&(ref->_service_period) - (char *)ref, -1));
+    table->addColumn(new OffsetStringColumn("debug_info",
+            "Debug information", (char *)&(ref->_debug_info) - (char *)ref, -1));
+    table->addColumn(new OffsetStringColumn("host_name",
+            "Host name", (char *)&(ref->_host_name) - (char *)ref, -1));
+    table->addColumn(new OffsetStringColumn("service_description",
+            "Description of the service", (char *)&(ref->_service_description) - (char *)ref, -1));
+    table->addColumn(new OffsetStringColumn("log_output",
+            "Logfile output relevant for this state", (char *)&(ref->_log_output) - (char *)ref, -1));
+    table->addColumn(new OffsetIntColumn("duration_ok",
+            "OK duration of state ( until - from )", (char *)&(ref->_duration_state_OK) - (char *)ref, -1));
+    table->addColumn(new OffsetDoubleColumn("duration_part_ok",
+            "OK duration part in regard to the query timeframe", (char *)(&ref->_duration_part_OK) - (char *)ref, -1));
+
+    table->addColumn(new OffsetIntColumn("duration_warning",
+            "WARNING duration of state (until - from)", (char *)&(ref->_duration_state_WARNING) - (char *)ref, -1));
+    table->addColumn(new OffsetDoubleColumn("duration_part_warning",
+            "WARNING duration part in regard to the query timeframe", (char *)(&ref->_duration_part_WARNING) - (char *)ref, -1));
+
+    table->addColumn(new OffsetIntColumn("duration_critical",
+            "CRITICAL duration of state (until - from)", (char *)&(ref->_duration_state_CRITICAL) - (char *)ref, -1));
+    table->addColumn(new OffsetDoubleColumn("duration_part_critical",
+            "CRITICAL duration part in regard to the query timeframe", (char *)(&ref->_duration_part_CRITICAL) - (char *)ref, -1));
+
+    table->addColumn(new OffsetIntColumn("duration_unknown",
+            "UNKNOWN duration of state (until - from)", (char *)&(ref->_duration_state_UNKNOWN) - (char *)ref, -1));
+    table->addColumn(new OffsetDoubleColumn("duration_part_unknown",
+            "UNKNOWN duration part in regard to the query timeframe", (char *)(&ref->_duration_part_UNKNOWN) - (char *)ref, -1));
+
+    table->addColumn(new OffsetIntColumn("duration_unmonitored",
+            "UNMONITORED duration of state (until - from)", (char *)&(ref->_duration_state_UNMONITORED) - (char *)ref, -1));
+    table->addColumn(new OffsetDoubleColumn("duration_part_unmonitored",
+            "UNMONITORED duration part in regard to the query timeframe", (char *)(&ref->_duration_part_UNMONITORED) - (char *)ref, -1));
+
+
+    // join host and service tables
+    g_table_hosts->addColumns(table, "current_host_", (char *)&(ref->_host)    - (char *)ref);
+    g_table_services->addColumns(table, "current_service_", (char *)&(ref->_service) - (char *)ref, false /* no hosts table */);
+
+
+    table->clearNatSort();
+    table->addNatSort( "host_name" );
+    table->addNatSort( "service_description" );
+}
+
+LogEntry *TableStateHistory::getPreviousLogentry()
+{
+    while (_it_entries == _entries->begin()) {
+        // open previous logfile
+        if (_it_logs == g_store->logCache()->logfiles()->begin())
+            return 0;
+        else {
+            _it_logs--;
+            _entries = _it_logs->second->getEntriesFromQuery(_query, g_store->logCache(), _since, _until, CLASSMASK_STATEHIST);
+            _it_entries = _entries->end();
+        }
+    }
+
+    return (--_it_entries)->second;
+}
+
+LogEntry *TableStateHistory::getNextLogentry()
+{
+    if (_it_entries != _entries->end())
+        ++_it_entries;
+
+    while (_it_entries == _entries->end()) {
+        _logfiles_t::iterator _it_logs_cpy = _it_logs;
+        if (++_it_logs_cpy == g_store->logCache()->logfiles()->end()) {
+            return 0;
+        }
+        else {
+            ++_it_logs;
+            _entries = _it_logs->second->getEntriesFromQuery(_query, g_store->logCache(), _since, _until, CLASSMASK_STATEHIST);
+            _it_entries = _entries->begin();
+        }
+    }
+    return _it_entries->second;
+
+}
+
+void TableStateHistory::answerQuery(Query *query)
+{
+    // Create a partial filter, that contains only such filters that
+    // check attributes of current hosts and services
+    typedef deque<Filter *> object_filter_t;
+    object_filter_t object_filter;
+    AndingFilter *orig_filter = query->filter();
+
+    if (!g_disable_statehist_filtering) {
+        deque<Filter *>::iterator it = orig_filter->begin();
+        while (it != orig_filter->end()) {
+            Filter *filter = *it;
+            Column *column = filter->column();
+            if (column) {
+                const char *column_name = column->name();
+                if (!strncmp(column_name, "current_", 8)
+                        || !strncmp(column_name, "host_", 5)
+                        || !strncmp(column_name, "service_", 8))
+                {
+                    object_filter.push_back(filter);
+                }
+            }
+            ++it;
+        }
+    }
+
+    g_store->logCache()->lockLogCache();
+    g_store->logCache()->logCachePreChecks();
+
+    // This flag might be set to true by the return value of processDataset(...)
+    _abort_query = false;
+
+    // Store hosts/services that we have filtered out here
+    typedef set<HostServiceKey> object_blacklist_t;
+    object_blacklist_t object_blacklist;
+
+    _query = query;
+    _since = 0;
+    _until = time(0) + 1;
+
+    // Optimize time interval for the query. In log querys
+    // there should always be a time range in form of one
+    // or two filter expressions over time. We use that
+    // to limit the number of logfiles we need to scan and
+    // to find the optimal entry point into the logfile
+    _query->findIntLimits("time", &_since, &_until);
+    if (_since == 0) {
+        query->setError(RESPONSE_CODE_INVALID_REQUEST, "Start of timeframe required. e.g. Filter: time > 1234567890");
+        g_store->logCache()->unlockLogCache();
+        return;
+    }
+
+    _query_timeframe = _until - _since - 1;
+    if (_query_timeframe == 0) {
+        query->setError(RESPONSE_CODE_INVALID_REQUEST, "Query timeframe is 0 seconds");
+        g_store->logCache()->unlockLogCache();
+        return;
+    }
+
+    // Switch to last logfile (we have at least one)
+    _it_logs = g_store->logCache()->logfiles()->end();
+    --_it_logs;
+    _logfiles_t::iterator newest_log = _it_logs;
+
+    // Now find the log where 'since' starts.
+    while (_it_logs != g_store->logCache()->logfiles()->begin() && _it_logs->first >= _since) {
+        --_it_logs; // go back in history
+    }
+
+    // Check if 'until' is within these logfiles
+    if (_it_logs->first > _until) {
+        // All logfiles are too new, invalid timeframe
+        // -> No data available. Return empty result.
+        g_store->logCache()->unlockLogCache();
+        return;
+    }
+
+
+    // Determine initial logentry
+    LogEntry* entry;
+    _entries = _it_logs->second->getEntriesFromQuery(query, g_store->logCache(), _since, _until, CLASSMASK_STATEHIST);
+    if (_entries->size() > 0 &&_it_logs != newest_log) {
+        _it_entries = _entries->end();
+        // Check last entry. If it's younger than _since -> use this logfile too
+        if (--_it_entries != _entries->begin()) {
+            entry = _it_entries->second;
+            if (entry->_time >= _since) {
+                _it_entries = _entries->begin();
+            }
+        }
+    } else
+        _it_entries = _entries->begin();
+
+    // From now on use getPreviousLogentry() / getNextLogentry()
+    HostServiceKey key;
+    bool only_update = true;
+    bool in_nagios_initial_states = false;
+
+    while (0 != (entry = getNextLogentry()))
+    {
+        if (_abort_query)
+            break;
+
+        if (entry->_time >= _until) {
+            getPreviousLogentry();
+            break;
+        }
+        if (only_update && entry->_time >= _since) {
+            // Reached start of query timeframe. From now on let's produce real output
+            // Update _from time of every state entry
+            state_info_t::iterator it_hst = _state_info.begin();
+            while (it_hst != _state_info.end()) {
+                it_hst->second->_from  = _since;
+                it_hst->second->_until = _since;
+                it_hst++;
+            }
+            only_update = false;
+        }
+
+        if (in_nagios_initial_states && !(entry->_type == STATE_SERVICE_INITIAL || entry->_type == STATE_HOST_INITIAL)) {
+            // Set still unknown hosts / services to unmonitored
+            state_info_t::iterator it_hst = _state_info.begin();
+            while (it_hst != _state_info.end())
+            {
+                HostServiceState* hst = it_hst->second;
+                if (hst->_may_no_longer_exist) {
+                    hst->_has_vanished = true;
+                }
+                it_hst++;
+            }
+            in_nagios_initial_states = false;
+        }
+
+        key = 0;
+        bool is_service = false;
+        switch (entry->_type) {
+        case ALERT_SERVICE:
+        case STATE_SERVICE:
+        case STATE_SERVICE_INITIAL:
+        case DOWNTIME_ALERT_SERVICE:
+        case FLAPPING_SERVICE:
+            key = entry->_service;
+            is_service = true;
+        case ALERT_HOST:
+        case STATE_HOST:
+        case STATE_HOST_INITIAL:
+        case DOWNTIME_ALERT_HOST:
+        case FLAPPING_HOST:
+        {
+            if (!is_service)
+                key = entry->_host;
+
+            if (key == 0)
+                continue;
+
+            if (object_blacklist.find(key) != object_blacklist.end())
+            {
+                // Host/Service is not needed for this query and has already
+                // been filtered out.
+                continue;
+            }
+
+            // Find state object for this host/service
+            HostServiceState *state;
+            state_info_t::iterator it_hst = _state_info.find(key);
+            if (it_hst == _state_info.end())
+            {
+                // Create state object that we also need for filtering right now
+                state = new HostServiceState();
+                state->_is_host             = entry->_svc_desc == 0;
+                state->_host                = entry->_host;
+                state->_service             = entry->_service;
+                state->_host_name           = entry->_host->name;
+                state->_service_description = entry->_service != 0 ? entry->_service->description : "";
+
+                // No state found. Now check if this host/services is filtered out.
+                // Note: we currently do not filter out hosts since they might be
+                // needed for service states
+                if (entry->_svc_desc)
+                {
+                    bool filtered_out = false;
+                    for (object_filter_t::iterator it = object_filter.begin();
+                         it != object_filter.end();
+                         ++it)
+                    {
+                        Filter *filter = *it;
+                        if (!filter->accepts(state)) {
+                            filtered_out = true;
+                            break;
+                        }
+                    }
+
+                    if (filtered_out) {
+                        object_blacklist.insert(key);
+                        delete state;
+                        continue;
+                    }
+                }
+
+                // Host/Service relations
+                if (state->_is_host) {
+                    state_info_t::iterator it_inh = _state_info.begin();
+                    while (it_inh != _state_info.end()) {
+                        if (it_inh->second->_host == state->_host){
+                            state->_services.push_back(it_inh->second);
+                        }
+                        it_inh++;
+                    }
+                } else {
+                    state_info_t::iterator it_inh = _state_info.find(state->_host);
+                    if (it_inh != _state_info.end())
+                        it_inh->second->_services.push_back(state);
+                }
+
+
+                // Store this state object for tracking state transitions
+                _state_info.insert(std::make_pair(key, state));
+                state->_from = _since;
+
+                // Get notification period of host/service
+                // If this host/service is no longer availabe in nagios -> set to ""
+                if (state->_service != 0)
+                    state->_notification_period = state->_service->notification_period;
+                else if (state->_host != 0)
+                    state->_notification_period = state->_host->notification_period;
+                else
+                    state->_notification_period = (char *)"";
+
+                // If for some reason the notification period is missing set a default
+                if (state->_notification_period == NULL) {
+                     state->_notification_period = (char *)"";
+                }
+
+                // Same for service period. For Nagios this is a bit different, since this
+                // is no native field but just a custom variable
+                if (state->_service != 0)
+                    state->_service_period = (char *)getCustomVariable(state->_service->custom_variables, "SERVICE_PERIOD");
+                else if (state->_host != 0)
+                    state->_service_period = (char *)getCustomVariable(state->_host->custom_variables, "SERVICE_PERIOD");
+                else
+                    state->_service_period = (char *)"";
+
+
+                // Determine initial in_notification_period status
+                _notification_periods_t::const_iterator tmp_period = _notification_periods.find(state->_notification_period);
+                if (tmp_period != _notification_periods.end())
+                    state->_in_notification_period = tmp_period->second;
+                else
+                    state->_in_notification_period = 1;
+
+                // Same for service period
+                tmp_period = _notification_periods.find(state->_service_period);
+                if (tmp_period != _notification_periods.end())
+                    state->_in_service_period = tmp_period->second;
+                else
+                    state->_in_service_period = 1;
+
+                // If this key is a service try to find its host and apply its _in_host_downtime and _host_down parameters
+                if (!state->_is_host) {
+                    state_info_t::iterator my_host = _state_info.find(state->_host);
+                    if (my_host != _state_info.end()) {
+                        state->_in_host_downtime = my_host->second->_in_host_downtime;
+                        state->_host_down        = my_host->second->_host_down;
+                    }
+                }
+
+                // Log UNMONITORED state if this host or service just appeared within the query timeframe
+                // It gets a grace period of ten minutes (nagios startup)
+                if  (!only_update && entry->_time - _since > 60 * 10) {
+                    state->_debug_info = "UNMONITORED ";
+                    state->_state      = -1;
+                }
+            }
+            else
+                state = it_hst->second;
+
+            int state_changed = updateHostServiceState(query, entry, state, only_update);
+            // Host downtime or state changes also affect its services
+            if (entry->_type == ALERT_HOST || entry->_type == STATE_HOST || entry->_type == DOWNTIME_ALERT_HOST){
+
+
+                if (state_changed != 0) {
+                    HostServices::iterator it_svc = state->_services.begin();
+                    while (it_svc != state->_services.end()) {
+                        updateHostServiceState(query, entry, *it_svc, only_update);
+                        it_svc++;
+                    }
+                }
+            }
+            break;
+        }
+        case TIMEPERIOD_TRANSITION:
+        {
+            char *save_ptr;
+            char *buffer   = strdup(entry->_options);
+            char *tp_name  = strtok_r(buffer, ";", &save_ptr);
+            char *tp_state = strtok_r(NULL, ";", &save_ptr);
+            if (tp_state)
+                tp_state = strtok_r(NULL, ";", &save_ptr);
+
+            if (tp_state == NULL) {
+                // This line is broken...
+                logger(LG_WARN, "Error: Invalid syntax of TIMEPERIOD TRANSITION: %s", entry->_complete);
+                free(buffer);
+                break;
+            }
+
+            _notification_periods[tp_name] = atoi(tp_state);
+            state_info_t::iterator it_hst = _state_info.begin();
+            while (it_hst != _state_info.end()) {
+                updateHostServiceState(query, entry, it_hst->second, only_update);
+                it_hst++;
+            }
+            free(buffer);
+            break;
+        }
+        case LOG_INITIAL_STATES:
+        {
+            // This feature is only available if log_initial_states is set to 1
+            // If log_initial_states is set, each nagios startup logs the initial states of all known
+            // hosts and services. Therefore we can detect if a host is no longer available after
+            // a nagios startup. If it still exists an INITIAL HOST/SERVICE state entry will follow up shortly.
+            state_info_t::iterator it_hst = _state_info.begin();
+            while (it_hst != _state_info.end()) {
+                if (!it_hst->second->_has_vanished) {
+                    it_hst->second->_last_known_time = entry->_time;
+                    it_hst->second->_may_no_longer_exist = true;
+                }
+                it_hst++;
+            }
+            in_nagios_initial_states = true;
+            break;
+        }
+        }
+    }
+
+    // Create final reports
+    state_info_t::iterator it_hst = _state_info.begin();
+    if (!_abort_query) {
+        while (it_hst != _state_info.end())
+        {
+            HostServiceState* hst = it_hst->second;
+
+            // No trace since the last two nagios startup -> host/service has vanished
+            if (hst->_may_no_longer_exist) {
+                // Log last known state up to nagios restart
+                hst->_time  = hst->_last_known_time;
+                hst->_until = hst->_last_known_time;
+                process(query, hst);
+                // Set absent state
+                hst->_state = -1;
+                hst->_until = hst->_time;
+                hst->_debug_info = "UNMONITORED";
+                if (hst->_log_output)
+                    free(hst->_log_output);
+                hst->_log_output = 0;
+            }
+
+            hst->_time  = _until - 1;
+            hst->_until = hst->_time;
+
+            process(query, hst);
+            it_hst++;
+        }
+    }
+    object_blacklist.clear();
+
+    g_store->logCache()->unlockLogCache();
+}
+
+void TableStateHistory::cleanupQuery(Query *query) {
+    state_info_t::iterator it_hst = _state_info.begin();
+    while (it_hst != _state_info.end()) {
+        delete it_hst->second;
+        it_hst++;
+    }
+    _state_info.clear();
+}
+
+bool TableStateHistory::objectFilteredOut(Query *query, void *entry)
+{
+    return false;
+}
+
+inline int TableStateHistory::updateHostServiceState(Query *query, const LogEntry *entry, HostServiceState *hs_state, const bool only_update){
+    int state_changed = 1;
+
+    // Revive host / service if it was unmonitored
+    if (entry->_type != TIMEPERIOD_TRANSITION && hs_state->_has_vanished)
+    {
+        hs_state->_time  = hs_state->_last_known_time;
+        hs_state->_until = hs_state->_last_known_time;
+        if (!only_update)
+            process(query, hs_state);
+
+        hs_state->_may_no_longer_exist = false;
+        hs_state->_has_vanished = false;
+        // Set absent state
+        hs_state->_state = -1;
+        hs_state->_debug_info = "UNMONITORED";
+        hs_state->_in_downtime = 0;
+        hs_state->_in_notification_period = 0;
+        hs_state->_in_service_period = 0;
+        hs_state->_is_flapping = 0;
+        if (hs_state->_log_output)
+            free(hs_state->_log_output);
+        hs_state->_log_output = 0;
+
+        // Apply latest notification period information and set the host_state to unmonitored
+        _notification_periods_t::const_iterator it_status = _notification_periods.find(hs_state->_notification_period);
+        if (it_status != _notification_periods.end()) {
+            hs_state->_in_notification_period = it_status->second;
+        }
+        else // No notification period information available -> within notification period
+            hs_state->_in_notification_period = 1;
+
+        // Same for service period
+        it_status = _notification_periods.find(hs_state->_service_period);
+        if (it_status != _notification_periods.end()) {
+            hs_state->_in_service_period = it_status->second;
+        }
+        else // No service period information available -> within service period
+            hs_state->_in_service_period = 1;
+    }
+
+    // Update basic information
+    hs_state->_time   = entry->_time;
+    hs_state->_lineno = entry->_lineno;
+    hs_state->_until  = entry->_time;
+
+    // A timeperiod entry never brings an absent host or service into existence..
+    if (entry->_type != TIMEPERIOD_TRANSITION)
+        hs_state->_may_no_longer_exist = false;
+
+    switch (entry->_type)
+    {
+    case STATE_HOST:
+    case STATE_HOST_INITIAL:
+    case ALERT_HOST:
+    {
+        if (hs_state->_is_host) {
+            if (hs_state->_state != entry->_state) {
+                if (!only_update)
+                    process(query, hs_state);
+                hs_state->_state      = entry->_state;
+                hs_state->_host_down  = entry->_state > 0;
+                hs_state->_debug_info = "HOST STATE";
+            } else
+                state_changed = 0;
+        }
+        else if (hs_state->_host_down != entry->_state > 0)
+        {
+            if (!only_update)
+                process(query, hs_state);
+            hs_state->_host_down  = entry->_state > 0;
+            hs_state->_debug_info = "SVC HOST STATE";
+
+        }
+        break;
+    }
+    case STATE_SERVICE:
+    case STATE_SERVICE_INITIAL:
+    case ALERT_SERVICE:
+    {
+        if (hs_state->_state != entry->_state) {
+            if (!only_update)
+                process(query, hs_state);
+            hs_state->_debug_info = "SVC ALERT";
+            hs_state->_state = entry->_state;
+        }
+        break;
+    }
+    case DOWNTIME_ALERT_HOST:
+    {
+        int downtime_active = !strncmp(entry->_state_type,"STARTED",7) ? 1 : 0;
+
+        if (hs_state->_in_host_downtime != downtime_active) {
+            if (!only_update)
+                process(query, hs_state);
+            hs_state->_debug_info       = hs_state->_is_host ? "HOST DOWNTIME" : "SVC HOST DOWNTIME";
+            hs_state->_in_host_downtime = downtime_active;
+            if (hs_state->_is_host)
+                hs_state->_in_downtime  = downtime_active;
+        } else
+            state_changed = 0;
+        break;
+    }
+    case DOWNTIME_ALERT_SERVICE:
+    {
+        int downtime_active = !strncmp(entry->_state_type,"STARTED",7) ? 1 : 0;
+        if (hs_state->_in_downtime != downtime_active) {
+            if (!only_update)
+                process(query, hs_state);
+            hs_state->_debug_info = "DOWNTIME SERVICE";
+            hs_state->_in_downtime = downtime_active;
+        }
+        break;
+
+    }
+    case FLAPPING_HOST:
+    case FLAPPING_SERVICE:
+    {
+        int flapping_active = !strncmp(entry->_state_type,"STARTED",7) ? 1 : 0;
+        if (hs_state->_is_flapping != flapping_active) {
+            if (!only_update)
+                process(query, hs_state);
+            hs_state->_debug_info = "FLAPPING ";
+            hs_state->_is_flapping = flapping_active;
+        } else
+            state_changed = 0;
+        break;
+    }
+    case TIMEPERIOD_TRANSITION:
+    {
+        char *save_ptr;
+        char *buffer   = strdup(entry->_options);
+        char *tp_name  = strtok_r(buffer, ";", &save_ptr);
+        strtok_r(NULL, ";", &save_ptr);
+        char *tp_state = strtok_r(NULL, ";", &save_ptr);
+
+        // if no _host pointer is available the initial status of _in_notification_period (1) never changes
+        if (hs_state->_host && !strcmp(tp_name, hs_state->_notification_period)) {
+            int new_status = atoi(tp_state);
+            if (new_status != hs_state->_in_notification_period) {
+                if (!only_update)
+                    process(query, hs_state);
+                hs_state->_debug_info = "TIMEPERIOD ";
+                hs_state->_in_notification_period = new_status;
+            }
+        }
+        // same for service period
+        if (hs_state->_host && !strcmp(tp_name, hs_state->_service_period)) {
+            int new_status = atoi(tp_state);
+            if (new_status != hs_state->_in_service_period) {
+                if (!only_update)
+                    process(query, hs_state);
+                hs_state->_debug_info = "TIMEPERIOD ";
+                hs_state->_in_service_period = new_status;
+            }
+        }
+        free(buffer);
+        break;
+    }
+    }
+
+    if (entry->_type != TIMEPERIOD_TRANSITION) {
+        if (hs_state->_log_output)
+            free(hs_state->_log_output);
+
+        if ( (entry->_type == STATE_HOST_INITIAL || entry->_type == STATE_SERVICE_INITIAL) &&
+             (entry->_check_output != 0 && !strcmp(entry->_check_output, "(null)")) )
+            hs_state->_log_output = 0;
+
+        else
+            hs_state->_log_output = entry->_check_output ? strdup(entry->_check_output) : 0;
+    }
+
+    return state_changed;
+}
+
+
+inline void TableStateHistory::process(Query *query, HostServiceState *hs_state)
+{
+    hs_state->_duration = hs_state->_until - hs_state->_from;
+    hs_state->_duration_part = (double)hs_state->_duration / (double)_query_timeframe;
+
+    bzero(&hs_state->_duration_state_UNMONITORED, sizeof(time_t) * 5 + sizeof(double) * 5);
+
+    switch (hs_state->_state) {
+    case -1:
+        hs_state->_duration_state_UNMONITORED = hs_state->_duration;
+        hs_state->_duration_part_UNMONITORED  = hs_state->_duration_part;
+        break;
+    case STATE_OK:
+        hs_state->_duration_state_OK          = hs_state->_duration;
+        hs_state->_duration_part_OK           = hs_state->_duration_part;
+        break;
+    case STATE_WARNING:
+        hs_state->_duration_state_WARNING     = hs_state->_duration;
+        hs_state->_duration_part_WARNING      = hs_state->_duration_part;
+        break;
+    case STATE_CRITICAL:
+        hs_state->_duration_state_CRITICAL    = hs_state->_duration;
+        hs_state->_duration_part_CRITICAL     = hs_state->_duration_part;
+        break;
+    case STATE_UNKNOWN:
+        hs_state->_duration_state_UNKNOWN     = hs_state->_duration;
+        hs_state->_duration_part_UNKNOWN      = hs_state->_duration_part;
+        break;
+    default:
+        break;
+    }
+
+    // if (hs_state->_duration > 0)
+    _abort_query = !query->processDataset(hs_state);
+
+    hs_state->_from = hs_state->_until;
+};
+
+bool TableStateHistory::isAuthorized(contact *ctc, void *data)
+{
+    HostServiceState *entry = (HostServiceState *)data;
+    service *svc = entry->_service;
+    host *hst = entry->_host;
+
+    if (hst || svc)
+        return is_authorized_for(ctc, hst, svc);
+    else
+        return false;
+}
+
+Column *TableStateHistory::column(const char *colname)
+{
+    // First try to find column in the usual way
+    Column *col = Table::column(colname);
+    if (col) return col;
+
+    // Now try with prefix "current_", since our joined
+    // tables have this prefix in order to make clear that
+    // we access current and not historic data and in order
+    // to prevent mixing up historic and current fields with
+    // the same name.
+    string with_current = string("current_") + colname;
+    return Table::column(with_current.c_str());
+}

--- a/src/logger.h
+++ b/src/logger.h
@@ -28,13 +28,12 @@
 #include "config.h"
 #include "nagios.h"
 
-// TODO: Really use log levels
 #define LG_INFO  NSLOG_INFO_MESSAGE
-#define LG_WARN  LOG_INFO
-#define LG_ERR   LOG_INFO
-#define LG_CRIT  LOG_INFO
-#define LG_DEBUG LOG_INFO
-#define LG_ALERT LOG_INFO
+#define LG_WARN  LG_INFO
+#define LG_ERR   LG_INFO
+#define LG_CRIT  LG_INFO
+#define LG_DEBUG LG_INFO
+#define LG_ALERT LG_INFO
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,4 +49,3 @@ void close_logfile();
 #endif
 
 #endif // logger_h
-

--- a/tests/features/statehist.feature
+++ b/tests/features/statehist.feature
@@ -1,0 +1,37 @@
+Feature: Statehist queries work as expected
+
+	Background: Set up naemon configuration
+		Given I have naemon hostgroup objects
+			| hostgroup_name |
+			| hg1			 |
+			| hg2		     |
+		And I have naemon host objects
+			| use			| host_name	| contacts			| hostgroups	|
+			| default-host	| host1		| default-contact	| hg1		|
+			| default-host	| host2		| default-contact	| hg2		|
+			| default-host	| host3		| default-contact	| hg2		|
+		And I have naemon service objects
+			| use			 | service_description | host_name 	|
+			| default-service| service1			   | host1 		|
+			| default-service| service2			   | host2 		|
+			| default-service| service3			   | host3 		|
+		And I start naemon
+
+	Scenario: Livestatus responds to queries on statehist table
+		Given I submit the following livestatus query
+			| GET statehist 							|
+			| Columns: host_name service_description 	|
+			| Filter: time >= 1500000000 				|
+			| Stats: sum duration_ok 					|
+			| Stats: sum duration_warning 				|
+			| Stats: sum duration_critical 				|
+			| Sort: host_name asc 						|
+		Then I should see the following livestatus response, using regular expression
+			"""
+			host1;;\d+;0;0
+			host1;service1;\d+;0;0
+			host2;;\d+;0;0
+			host2;service2;\d+;0;0
+			host3;;\d+;0;0
+			host3;service3;\d+;0;0
+			"""

--- a/tests/features/step_definitions/livestatus.rb
+++ b/tests/features/step_definitions/livestatus.rb
@@ -16,6 +16,12 @@ Then /^I should see the following livestatus response, ignoring whitespace$/ do 
   processed_response.should == processed_output
 end
 
+Then /^I should see the following livestatus response, using regular expression$/ do |output|
+  response = @naemon.brokers[:livestatus].last_response()
+  processed_response = response.join("\n")
+  expect(processed_response).to match(output)
+end
+
 Given /^I clobber livestatus with (\d+) queries with (\d+) seconds idle time$/ do |nqueries, idle_time|
   @naemon.brokers[:livestatus].clobber(nqueries, idle_time)
 end
@@ -32,5 +38,5 @@ Then /^the slowest query should be no more than (\d+) times slower than the fast
 end
 
 Then /^the average query response time should be no more than (\d+.\d+) seconds$/ do |threshold|
-  @naemon.brokers[:livestatus].clobber_data()['avg_time'].should < threshold.to_f 
+  @naemon.brokers[:livestatus].clobber_data()['avg_time'].should < threshold.to_f
 end

--- a/tests/features/support/naemon.rb
+++ b/tests/features/support/naemon.rb
@@ -9,15 +9,15 @@ class Naemon
       :command_file => "naemon.cmd",
       :lock_file => "naemon.pid",
       :log_file => "naemon.log",
-      :query_socket => "naemon.qh"
-
+      :query_socket => "naemon.qh",
+      :log_initial_states => "1"
     }
     @oconf = nil
     @brokers = {}
   end
 
   def set_object_config(objectconfig)
-    @configuration[:cfg_file] = "objects.cfg" 
+    @configuration[:cfg_file] = "objects.cfg"
     @oconf = objectconfig
   end
 


### PR DESCRIPTION
The statehist table allows to calulate and query availability data
based on logfiles. This PR backports the statehist table from the
mk-livestatus from commit 9bd68ac8edf3f3c34a760d0cb9596216ce232df5.
(https://github.com/tribe29/checkmk/commit/9bd68ac8edf3f3c34a760d0cb9596216ce232df5)
That commit is not related to the statehist table, but is the most
recent commit before some major rewrites happended upstream.
Some changes had to be done to delay cleanup, otherwise sorting and
grouping fails with naemon-livestatus.