### PR TITLE
fix wrong placed paranthesis (code can behave buggy)

### DIFF
--- a/src/HostlistDependencyColumnFilter.cc
+++ b/src/HostlistDependencyColumnFilter.cc
@@ -22,7 +22,7 @@ bool HostlistDependencyColumnFilter::accepts(void *data)
     objectlist *list = _hostlist_dependency_column->getList(data);
 
     // test for empty list
-    if(abs(_opid == OP_EQUAL) && _ref_host == "")
+    if(abs(_opid) == OP_EQUAL && _ref_host == "") // bugfix (found by clang warning -Wabsolute-value)
         return (list == 0) == (_opid == OP_EQUAL);
 
     bool is_member = false;

--- a/src/ServicelistColumnFilter.cc
+++ b/src/ServicelistColumnFilter.cc
@@ -60,7 +60,7 @@ bool ServicelistColumnFilter::accepts(void *data)
     servicesmember *mem = _servicelist_column->getMembers(data);
 
     // test for empty list
-    if (abs(_opid == OP_EQUAL) && _ref_host == "")
+    if (abs(_opid) == OP_EQUAL && _ref_host == "") // bugfix (found by clang warning -Wabsolute-value)
         return (mem == 0) == (_opid == OP_EQUAL);
 
     bool is_member = false;

--- a/src/ServicelistDependencyColumnFilter.cc
+++ b/src/ServicelistDependencyColumnFilter.cc
@@ -33,7 +33,7 @@ bool ServicelistDependencyColumnFilter::accepts(void *data)
     objectlist *list = _servicelist_dependency_column->getList(data);
 
     // test for empty list
-    if(abs(_opid == OP_EQUAL) && _ref_service == "")
+    if(abs(_opid) == OP_EQUAL && _ref_service == "") // bugfix (found by clang warning -Wabsolute-value)
         return (list == 0) == (_opid == OP_EQUAL);
 
     bool is_member = false;


### PR DESCRIPTION
split-out of https://github.com/naemon/naemon-livestatus/pull/71

in other parts of the code the "abs(_opid)" is already existing, so 3 typos are fixed hereby