### PR TITLE
release 1.2.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+naemon-livestatus (1.2.1) UNRELEASED; urgency=low
+
+  * new upstream release
+
+ -- Naemon Development Team <naemon-dev@monitoring-lists.org>  Mon, 13 Jul 2020 12:29:52 +0200
+
 naemon-livestatus (1.2.0) UNRELEASED; urgency=low
 
   * new upstream release

--- a/naemon-livestatus.spec
+++ b/naemon-livestatus.spec
@@ -1,6 +1,6 @@
 Summary: Naemon Livestatus Eventbroker Module
 Name: naemon-livestatus
-Version: 1.2.0
+Version: 1.2.1
 Release: 0
 License: GPL-2.0-only
 Group: Applications/System

--- a/version.sh
+++ b/version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=1.2.0
+VERSION=1.2.1
 if test -e .git; then
     if hash git 2>/dev/null; then
         VERSION=$(git describe --tag --exact-match 2>/dev/null | sed -e 's/^v//')


### PR DESCRIPTION
    Changes:

        * Increase max_response_size default to 500 MiB

    Bugfixes:

        * Fix build issues with recent gcc and glibc versions