### PR TITLE
fix wording in table descriptions

### DIFF
--- a/src/TableContacts.cc
+++ b/src/TableContacts.cc
@@ -62,16 +62,16 @@ void TableContacts::addColumns(Table *table, string prefix, int indirect_offset)
     }
 
     table->addColumn(new OffsetIntColumn(prefix + "can_submit_commands",
-                "Wether the contact is allowed to submit commands (0/1)", (char *)&ctc.can_submit_commands - ref, indirect_offset));
+                "Whether the contact is allowed to submit commands (0/1)", (char *)&ctc.can_submit_commands - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "host_notifications_enabled",
-                "Wether the contact will be notified about host problems in general (0/1)", (char *)&ctc.host_notifications_enabled - ref, indirect_offset));
+                "Whether the contact will be notified about host problems in general (0/1)", (char *)&ctc.host_notifications_enabled - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "service_notifications_enabled",
-                "Wether the contact will be notified about service problems in general (0/1)", (char *)&ctc.service_notifications_enabled - ref, indirect_offset));
+                "Whether the contact will be notified about service problems in general (0/1)", (char *)&ctc.service_notifications_enabled - ref, indirect_offset));
 
     table->addColumn(new OffsetTimeperiodColumn(prefix + "in_host_notification_period",
-                "Wether the contact is currently in his/her host notification period (0/1)", (char *)&ctc.host_notification_period_ptr - ref, indirect_offset));
+                "Whether the contact is currently in his/her host notification period (0/1)", (char *)&ctc.host_notification_period_ptr - ref, indirect_offset));
     table->addColumn(new OffsetTimeperiodColumn(prefix + "in_service_notification_period",
-                "Wether the contact is currently in his/her service notification period (0/1)", (char *)&ctc.service_notification_period_ptr - ref, indirect_offset));
+                "Whether the contact is currently in his/her service notification period (0/1)", (char *)&ctc.service_notification_period_ptr - ref, indirect_offset));
 
     table->addColumn(new CustomVarsColumn(prefix + "custom_variable_names",
                 "A list of all custom variables of the contact", (char *)(&ctc.custom_variables) - ref, indirect_offset, CVT_VARNAMES));

--- a/src/TableHosts.cc
+++ b/src/TableHosts.cc
@@ -280,7 +280,7 @@ void TableHosts::addColumns(Table *table, string prefix, int indirect_offset)
     table->addColumn(new HostlistColumn(prefix + "parents",
                 "A list of all direct parents of the host", (char *)(&hst.parent_hosts) - ref, indirect_offset, false));
     table->addColumn(new HostlistColumn(prefix + "childs",
-                "A list of all direct childs of the host", (char *)(&hst.child_hosts) - ref, indirect_offset, false));
+                "A list of all direct children of the host", (char *)(&hst.child_hosts) - ref, indirect_offset, false));
 
     table->addColumn(new HostlistDependencyColumn(prefix + "depends_exec",
                 "A list of all hosts this hosts depends on to execute", (char *)(&hst.exec_deps) - ref, indirect_offset, false));

--- a/src/TableServices.cc
+++ b/src/TableServices.cc
@@ -281,7 +281,7 @@ void TableServices::addColumns(Table *table, string prefix, int indirect_offset,
     table->addColumn(new OffsetIntColumn(prefix + "acknowledged",
                 "Whether the current service problem has been acknowledged (0/1)", (char *)&svc.problem_has_been_acknowledged - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "acknowledgement_type",
-                "The type of the acknownledgement (0: none, 1: normal, 2: sticky)", (char *)&svc.acknowledgement_type - ref, indirect_offset));
+                "The type of the acknowledgement (0: none, 1: normal, 2: sticky)", (char *)&svc.acknowledgement_type - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "no_more_notifications",
                 "Whether to stop sending notifications (0/1)", (char *)(&svc.no_more_notifications) - ref, indirect_offset));
     table->addColumn(new OffsetTimeColumn(prefix + "last_state_change",
@@ -413,7 +413,7 @@ void TableServices::addColumns(Table *table, string prefix, int indirect_offset,
     table->addColumn(new CustomVarsColumn(prefix + "custom_variable_values",
                 "A list of the values of all custom variable of the service", (char *)(&svc.custom_variables) - ref, indirect_offset, CVT_VALUES));
     table->addColumn(new CustomVarsColumn(prefix + "custom_variables",
-                "A dictorionary of the custom variables", (char *)(&svc.custom_variables) - ref, indirect_offset, CVT_DICT));
+                "A dictionary of the custom variables", (char *)(&svc.custom_variables) - ref, indirect_offset, CVT_DICT));
 
     table->addColumn(new ServicegroupsColumn(prefix + "groups",
                 "A list of all service groups the service is in", (char *)(&svc.servicegroups_ptr) - ref, indirect_offset));

--- a/src/TableStatus.cc
+++ b/src/TableStatus.cc
@@ -100,7 +100,7 @@ TableStatus::TableStatus()
     addColumn(new GlobalCountersColumn("livechecks",
                 "The number of checks executed via livecheck",                COUNTER_LIVECHECKS,    false));
     addColumn(new GlobalCountersColumn("livechecks_rate",
-                "The averaged number of livechecks executes per second",      COUNTER_LIVECHECKS,    true));
+                "The averaged number of livechecks executed per second",      COUNTER_LIVECHECKS,    true));
 
     addColumn(new GlobalCountersColumn("livecheck_overflows",
                 "The number of times a check could not be executed "


### PR DESCRIPTION
These changes had been made to the livestatus docs on naemon.org already.
But since those docs are generated, we need to make the changes here as well.