### PR TITLE
speed up contacts host/service column

### DIFF
--- a/src/ContactsColumn.cc
+++ b/src/ContactsColumn.cc
@@ -28,6 +28,12 @@
 #include "logger.h"
 #include "Query.h"
 #include "tables.h"
+#include "nagios.h"
+
+bool compare_contactsmember(const contactsmember *m1, const contactsmember *m2)
+{
+    return(m1->contact_name < m2->contact_name);
+}
 
 void *ContactsColumn::getNagiosObject(char *name)
 {
@@ -68,4 +74,3 @@ bool ContactsColumn::isEmpty(void *svc)
     }
     return true;
 }
-

--- a/src/ContactsColumn.h
+++ b/src/ContactsColumn.h
@@ -26,6 +26,9 @@
 #define ContactsColumn_h
 
 #include "config.h"
+#include "nagios.h"
+
+bool compare_contactsmember(const contactsmember *m1, const contactsmember *m2);
 
 #include "ListColumn.h"
 class TableContacts;

--- a/src/HostContactsColumn.cc
+++ b/src/HostContactsColumn.cc
@@ -24,11 +24,64 @@
 
 #include "nagios.h"
 #include "HostContactsColumn.h"
-#include "logger.h"
+#include "Query.h"
+#include <list>
 
 bool HostContactsColumn::isNagiosMember(void *hst, void *ctc)
 {
-    bool is_member = is_contact_for_host((host *)hst, (contact *)ctc);
-    return is_member;
+    return is_contact_for_host((host *)hst, (contact *)ctc);
 }
 
+void HostContactsColumn::output(void *data, Query *query)
+{
+    host *hst;
+    data = shiftPointer(data);
+
+    // create list of contacts by merging contacts and contact group members
+    std::list<contactsmember*> result;
+    if(hst) {
+        hst = (host *)data;
+        contactsmember *cm = hst->contacts;
+        while(cm) {
+            contact *ctc = cm->contact_ptr;
+            result.push_back(cm);
+            cm = cm->next;
+        }
+
+        contactgroupsmember *cgm = hst->contact_groups;
+        while(cgm) {
+            contactsmember *cm = cgm->group_ptr->members;
+            while(cm) {
+                result.push_back(cm);
+                cm = cm->next;
+            }
+            cgm = cgm->next;
+        }
+        result.sort(compare_contactsmember);
+        result.unique();
+    }
+
+    query->outputBeginList();
+    bool first = true;
+    for (std::list<contactsmember*>::iterator it = result.begin(); it != result.end(); ++it) {
+        if (first)
+            first = false;
+        else
+            query->outputListSeparator();
+        query->outputString(((contactsmember*)*it)->contact_name);
+    }
+    query->outputEndList();
+}
+
+bool HostContactsColumn::isEmpty(void *data)
+{
+    host *hst;
+    data = shiftPointer(data);
+    if(data) {
+        hst = (host *)data;
+        if(hst->contacts != NULL || hst->contact_groups != NULL) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/HostContactsColumn.h
+++ b/src/HostContactsColumn.h
@@ -36,7 +36,8 @@ public:
         : ContactsColumn(name, description, indirect_offset) {}
     int type() { return COLTYPE_LIST; }
     bool isNagiosMember(void *data, void *member);
+    bool isEmpty(void *data);
+    void output(void *, Query *);
 };
 
 #endif // HostContactsColumn_h
-

--- a/src/ServiceContactsColumn.cc
+++ b/src/ServiceContactsColumn.cc
@@ -24,11 +24,64 @@
 
 #include "nagios.h"
 #include "ServiceContactsColumn.h"
-
+#include "Query.h"
+#include <list>
 
 bool ServiceContactsColumn::isNagiosMember(void *svc, void *ctc)
 {
     return is_contact_for_service((service *)svc, (contact *)ctc);
 }
 
+void ServiceContactsColumn::output(void *data, Query *query)
+{
+    service *svc;
+    data = shiftPointer(data);
 
+    // create list of contacts by merging contacts and contact group members
+    std::list<contactsmember*> result;
+    if(data) {
+        svc = (service *)data;
+        contactsmember *cm = svc->contacts;
+        while(cm) {
+            contact *ctc = cm->contact_ptr;
+            result.push_back(cm);
+            cm = cm->next;
+        }
+
+        contactgroupsmember *cgm = svc->contact_groups;
+        while(cgm) {
+            contactsmember *cm = cgm->group_ptr->members;
+            while(cm) {
+                result.push_back(cm);
+                cm = cm->next;
+            }
+            cgm = cgm->next;
+        }
+        result.sort(compare_contactsmember);
+        result.unique();
+    }
+
+    query->outputBeginList();
+    bool first = true;
+    for (std::list<contactsmember*>::iterator it = result.begin(); it != result.end(); ++it) {
+        if (first)
+            first = false;
+        else
+            query->outputListSeparator();
+        query->outputString(((contactsmember*)*it)->contact_name);
+    }
+    query->outputEndList();
+}
+
+bool ServiceContactsColumn::isEmpty(void *data)
+{
+    service *svc;
+    data = shiftPointer(data);
+    if(data) {
+        svc = (service *)data;
+        if(svc->contacts != NULL || svc->contact_groups != NULL) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/ServiceContactsColumn.h
+++ b/src/ServiceContactsColumn.h
@@ -36,7 +36,8 @@ public:
         : ContactsColumn(name, description, indirect_offset) {}
     int type() { return COLTYPE_LIST; }
     bool isNagiosMember(void *data, void *member);
+    bool isEmpty(void *data);
+    void output(void *, Query *);
 };
 
 #endif // ServiceContactsColumn_h
-


### PR DESCRIPTION
the default contacts column iterates over each available contact and checks
with isNagiosMember() if this contact is valid for the given hst/svc which in
turn calls is_contact_for_service() which simply iterates over all service
contacts and then over all contactgroups with all its members to see if the
contact matches. That's quite a number of nested loops just to get the contacts
list of a host/service. This scales accidentally quadratic with the number of
services/hosts/contacts.

We now calculate the contacts based on the contacts and contactgroup members on
the fly to avoid the nested loops. Since the list could then contain duplicates
and is not sorted we have to do apply sorting again to match the previous
result.

Signed-off-by: Sven Nierlein <sven@nierlein.de>