### PR TITLE
Correct contacts column on host table

### DIFF
--- a/src/HostContactsColumn.cc
+++ b/src/HostContactsColumn.cc
@@ -34,13 +34,12 @@ bool HostContactsColumn::isNagiosMember(void *hst, void *ctc)
 
 void HostContactsColumn::output(void *data, Query *query)
 {
-    host *hst;
     data = shiftPointer(data);
+    host *hst = (host *)data;
 
     // create list of contacts by merging contacts and contact group members
     std::list<contactsmember*> result;
     if(hst) {
-        hst = (host *)data;
         contactsmember *cm = hst->contacts;
         while(cm) {
             contact *ctc = cm->contact_ptr;

--- a/tests/features/queries.feature
+++ b/tests/features/queries.feature
@@ -54,3 +54,13 @@ Feature: Queries work as expected
 			|Columns: host_comments|
 		Then I should see the following livestatus response
 			|1|
+
+	Scenario: Livestatus host lists contacts
+		Given I submit the following livestatus query
+			|GET hosts|
+			|Columns: host_name|
+			|Columns: contacts|
+		Then I should see the following livestatus response
+			|host1;default-contact|
+			|host2;default-contact|
+			|host3;default-contact|


### PR DESCRIPTION
Move the assignment of the hst variable before the if statement, to
ensure the if statement doesn't always return false.

This fixes an issue causing the contacts column on the host table to
always be empty.

Also add a test case for sanity checking.

Signed-off-by: Jacob Hansen <jhansen@op5.com>