### PR TITLE
fix listing contacts twice (fixes #90)

### DIFF
--- a/src/ContactsColumn.cc
+++ b/src/ContactsColumn.cc
@@ -35,6 +35,11 @@ bool compare_contactsmember(const contactsmember *m1, const contactsmember *m2)
     return(m1->contact_name < m2->contact_name);
 }
 
+bool equals_contactsmember(const contactsmember *m1, const contactsmember *m2)
+{
+    return(m1->contact_ptr == m2->contact_ptr);
+}
+
 void *ContactsColumn::getNagiosObject(char *name)
 {
     return (void *)find_contact(name);

--- a/src/ContactsColumn.h
+++ b/src/ContactsColumn.h
@@ -29,6 +29,7 @@
 #include "nagios.h"
 
 bool compare_contactsmember(const contactsmember *m1, const contactsmember *m2);
+bool equals_contactsmember(const contactsmember *m1, const contactsmember *m2);
 
 #include "ListColumn.h"
 class TableContacts;

--- a/src/HostContactsColumn.cc
+++ b/src/HostContactsColumn.cc
@@ -57,7 +57,7 @@ void HostContactsColumn::output(void *data, Query *query)
             cgm = cgm->next;
         }
         result.sort(compare_contactsmember);
-        result.unique();
+        result.unique(equals_contactsmember);
     }
 
     query->outputBeginList();

--- a/src/ServiceContactsColumn.cc
+++ b/src/ServiceContactsColumn.cc
@@ -58,7 +58,7 @@ void ServiceContactsColumn::output(void *data, Query *query)
             cgm = cgm->next;
         }
         result.sort(compare_contactsmember);
-        result.unique();
+        result.unique(equals_contactsmember);
     }
 
     query->outputBeginList();


### PR DESCRIPTION
std::list->unique fails to compare contact_members properly, because each
contact member instance has its own pointer. To fix this, we add a unique
callback which compares the underlying contact pointer.

Signed-off-by: Sven Nierlein <sven@nierlein.de>