### PR TITLE
Port Python 2 API to Python 3

### DIFF
--- a/api/python/__init__.py
+++ b/api/python/__init__.py
@@ -1,9 +1,20 @@
-from livestatus import SingleSiteConnection, MultiSiteConnection, MKLivestatusException, MKLivestatusSocketError, MKLivestatusSocketClosed, MKLivestatusQueryError, MKLivestatusNotFoundError
+from __future__ import absolute_import
+from .livestatus import (
+    SingleSiteConnection,
+    MultiSiteConnection,
+    MKLivestatusException,
+    MKLivestatusSocketError,
+    MKLivestatusSocketClosed,
+    MKLivestatusQueryError,
+    MKLivestatusNotFoundError,
+)
+
 __all__ = [
-    'SingleSiteConnection',
-    'MultiSiteConnection',
-    'MKLivestatusException',
-    'MKLivestatusSocketError',
-    'MKLivestatusSocketClosed',
-    'MKLivestatusQueryError',
-    'MKLivestatusNotFoundError']
+    "SingleSiteConnection",
+    "MultiSiteConnection",
+    "MKLivestatusException",
+    "MKLivestatusSocketError",
+    "MKLivestatusSocketClosed",
+    "MKLivestatusQueryError",
+    "MKLivestatusNotFoundError",
+]


### PR DESCRIPTION
Copy livestatus Python API from `api/python` to `api/python3` and make
necessary changes to run under Python 3 (somewhat tested on 3.6).

The original GPL'ed sources are from commit
e06cefeaaa619e260adb5bcceb82d04e19780e35.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>