### PR TITLE
Handling of multiline output in checks via LiveStatus

### DIFF
--- a/src/Store.cc
+++ b/src/Store.cc
@@ -134,7 +134,7 @@ bool Store::answerRequest(InputBuffer *input, OutputBuffer *output)
     else if (!strcmp(line, "GET"))
         answerGetRequest(input, output, ""); // only to get error message
     else if (!strncmp(line, "COMMAND ", 8)) {
-        answerCommandRequest(lstrip((char *)line + 8), output);
+        answerCommandRequest(unescape_newlines(lstrip((char *)line + 8)), output);
         output->setDoKeepalive(true);
     }
     else if (!strncmp(line, "LOGROTATE", 9)) {

--- a/src/strutil.cc
+++ b/src/strutil.cc
@@ -105,3 +105,31 @@ int ends_with(const char *a, const char *b)
 }
 
 
+/* unescapes newlines in a string */
+char *unescape_newlines(char *rawbuf) {
+  register int x, y;
+
+  for(x = 0, y = 0; rawbuf[x] != (char)'\x0'; x++) {
+
+    if(rawbuf[x] == '\\') {
+
+      /* unescape newlines */
+      if(rawbuf[x + 1] == 'n') {
+        rawbuf[y++] = '\n';
+        x++;
+        }
+
+      /* unescape backslashes and other stuff */
+      else if(rawbuf[x + 1] != '\x0') {
+        rawbuf[y++] = rawbuf[x + 1];
+        x++;
+        }
+
+      }
+    else
+      rawbuf[y++] = rawbuf[x];
+    }
+  rawbuf[y] = '\x0';
+
+  return rawbuf;
+  }

--- a/src/strutil.h
+++ b/src/strutil.h
@@ -41,6 +41,7 @@ extern "C" {
     char *save_next_token(char **c, char delim);
 #endif
     char *next_field(char **line);
+    char *unescape_newlines(char *);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/features/queries.feature
+++ b/tests/features/queries.feature
@@ -64,3 +64,13 @@ Feature: Queries work as expected
 			|host1;default-contact|
 			|host2;default-contact|
 			|host3;default-contact|
+
+	Scenario: Submit multiline plugin output
+		Given I submit the following livestatus external command "PROCESS_SERVICE_CHECK_RESULT;host1;service1;0;A short output\\\nFirst line of long output\\\nSecond line of long output"
+		And I submit the following livestatus query
+			|GET services|
+			|Filter: host_name = host1|
+			|Filter: description = service1|
+			|Columns: plugin_output long_plugin_output|
+		Then I should see the following raw livestatus response
+			|A short output;First line of long output\\u005cnSecond line of long output|

--- a/tests/features/step_definitions/livestatus.rb
+++ b/tests/features/step_definitions/livestatus.rb
@@ -2,6 +2,17 @@ Given /^I submit the following livestatus query$/ do |table|
   @naemon.brokers[:livestatus].query(table.raw.join('\n'))
 end
 
+Given(/^I submit the following livestatus external command "(.*?)"$/) do |cmd|
+  @naemon.brokers[:livestatus].query("COMMAND [#{Time.now.to_i}] #{cmd}")
+end
+
+Then /^I should see the following raw livestatus response$/ do |table|
+  response = @naemon.brokers[:livestatus].last_response()
+  table.raw.each_with_index do |line, idx|
+    response[idx].should == "\"#{line[0]}\"".undump
+  end
+end
+
 Then /^I should see the following livestatus response$/ do |table|
   response = @naemon.brokers[:livestatus].last_response()
   table.raw.each_with_index do |line, idx|


### PR DESCRIPTION
As described in naemon/naemon-core#387, outputs (from passive checks) submitted through LiveStatus were not properly processed, in that the whole output was assigned to `plugin_output` regardless of whether it had multiple lines - or not.

The main reason is that LiveStatus being a line-oriented protocol, it was not easy to submit outputs with a linefeed `\n` in them - as this would truncate the line at the `\n` boundary.

This PR intends to fix that, by allowing an escaped syntax for linefeed : `\\n` (and other control characters) when processing output submitted via LiveStatus.
(This was the behaviour of Nagios 3.x - but the implementation may differ).

This PR works by introducing a new `unescape_newlines` function [shamelessly stolen from Nagios](https://github.com/NagiosEnterprises/nagioscore/blob/3f6946590b9c2e74bda845d3f57703d2ba9f82e6/cgi/cgiutils.c#L855-L881), that will convert `\\n` (or any `\\X` control characters) to their proper value.

A test scenario has been written to validate and protect against possible future regression.

Example:
```
echo "COMMAND [$(date +%s)] PROCESS_SERVICE_CHECK_RESULT;HOST;SERVICE;0;A short output\\nFirst line of long output\\nSecond line of long output" | unixcat /var/spool/nagios/rw/live
```