### PR TITLE
Fix issue #99

### DIFF
--- a/naemon-livestatus.spec
+++ b/naemon-livestatus.spec
@@ -16,6 +16,7 @@ BuildRequires: libtool
 BuildRequires: gcc-c++
 %if 0%{?el8}
 BuildRequires: gdb-headless
+%endif
 
 # On Fedora-33+ and RHEL-8+, %__python triggers an error.
 %if 0%{?fedora} > 32 || 0%{?rhel} > 7

--- a/naemon-livestatus.spec
+++ b/naemon-livestatus.spec
@@ -16,8 +16,11 @@ BuildRequires: libtool
 BuildRequires: gcc-c++
 %if 0%{?el8}
 BuildRequires: gdb-headless
-%endif
 
+# On Fedora-33+ and RHEL-8+, %__python triggers an error.
+%if 0%{?fedora} > 32 || 0%{?rhel} > 7
+%define __python %__python3
+%endif
 
 %description
 Naemon-livestatus is an eventbroker module for naemon which allows


### PR DESCRIPTION
Add the following lines to the rpm spec file to fix build on recent rpm distributions (fedora > 32 and RHEL > 7 at least).
%__python macro is not allowed anymore and will produce an error.
%__python2 or %__python3 must be used to clarify which python version needs to be used.

BTW, python2 is deprecated.

# On Fedora-33+ and RHEL-8+, %__python triggers an error.
%if 0%{?fedora} > 32 || 0%{?rhel} > 7
%define __python %__python3
%endif
