### PR TITLE
fix g_tree_foreach: assertion `tree != NULL' failed

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   citest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       #- name: Setup tmate session, see https://github.com/marketplace/actions/debugging-with-tmate

--- a/src/HostlistColumn.cc
+++ b/src/HostlistColumn.cc
@@ -75,6 +75,10 @@ void HostlistColumn::output(void *data, Query *query)
 {
     query->outputBeginList();
     GTree *mem = getMembers(data);
+    if(mem == NULL) {
+        query->outputEndList();
+        return;
+    }
     output_parameters params;
     params.query = query;
     params.first = true;
@@ -87,4 +91,3 @@ Filter *HostlistColumn::createFilter(int opid, char *value)
 {
     return new HostlistColumnFilter(this, opid, value);
 }
-

--- a/src/HostlistStateColumn.cc
+++ b/src/HostlistStateColumn.cc
@@ -111,7 +111,8 @@ int32_t HostlistStateColumn::getValue(void *data, Query *query)
     params.query = query;
     params.logictype = _logictype;
     params.result = 0;
+    if(mem == NULL)
+        return params.result;
     g_tree_foreach(mem, get_subvalue, &params);
     return params.result;
 }
-


### PR DESCRIPTION
When requesting logs without specifing columns, the result contains hostlists. But since not all log entries do have hosts, this leads to a g_tree_foreach for a null tree. Checking the tree before calling g_tree_foreach fixes this issue.

might be related to #29 and #28