### PR TITLE
Tests: Update OS to Ubuntu 22.04

### DIFF
--- a/.github/workflows/citest.yml
+++ b/.github/workflows/citest.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   citest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       #- name: Setup tmate session, see https://github.com/marketplace/actions/debugging-with-tmate
@@ -23,10 +23,12 @@ jobs:
           sudo apt-get install build-essential
           sudo apt-get install libcppunit-dev
           sudo apt-get install libglib2.0-dev
+          sudo apt-get install libtool
           sudo apt-get install naemon-dev
           sudo apt-get install naemon-core
           sudo apt-get install ruby ruby-dev
-          sudo gem install cucumber:1.3.18 websocket-driver:0.7.0 nokogiri:1.6.0 rack:1.6.5 rack-test:0.7.0 capybara:2.1.0 public_suffix:2.0.5 xpath:2.0 rspec:2.14.1 parallel_tests syntax:1.0.0 cliver:0.3.2
+          sudo apt-get install zlib1g-dev liblzma-dev patch # required for nokogiri
+          sudo gem install cucumber:1.3.18 websocket-driver:0.7.0 nokogiri:1.11.0 rack:1.6.5 rack-test:0.7.0 capybara:2.1.0 public_suffix:2.0.5 xpath:2.0 rspec:2.14.1 parallel_tests syntax:1.0.0 cliver:0.3.2
 
       - name: run build
         run: |


### PR DESCRIPTION
Update the test OS to Ubuntu 22.04, and update nokogiri to version 1.11.0 for compatibility with Ruby 3.