### PR TITLE
do not print error message if client dissconects

### DIFF
--- a/src/InputBuffer.cc
+++ b/src/InputBuffer.cc
@@ -158,7 +158,7 @@ int InputBuffer::readRequest()
         {
             if (_read_pointer == r) { // empty line found => end of request
                 _read_pointer = r + 1;
-                // Was ist, wenn noch keine korrekte Zeile gelesen wurde?
+                // no valid line read yet
                 if (_requestlines.size() == 0) {
                     return IB_EMPTY_REQUEST;
                 }
@@ -242,4 +242,3 @@ bool timeout_reached(const struct timeval *start, int timeout_ms)
     elapsed += now.tv_usec - start->tv_usec;
     return elapsed / 1000 >= timeout_ms;
 }
-

--- a/src/Store.cc
+++ b/src/Store.cc
@@ -120,7 +120,7 @@ bool Store::answerRequest(InputBuffer *input, OutputBuffer *output)
     output->reset();
     int r = input->readRequest();
     if (r != IB_REQUEST_READ) {
-        if (r != IB_END_OF_FILE)
+        if (r != IB_END_OF_FILE && r != IB_EMPTY_REQUEST)
             output->setError(RESPONSE_CODE_INCOMPLETE_REQUEST,
                 "Client connection terminated while request still incomplete");
         return false;


### PR DESCRIPTION
Getting a log of "Client connection terminated while request still incomplete" messages in the livestatus lately. I guess it is because of keepalive queries which then finally terminate. So do not print that error if the request is empty.