### PR TITLE
Include explicitly pthread headers

### DIFF
--- a/src/LogCache.cc
+++ b/src/LogCache.cc
@@ -24,6 +24,7 @@
 
 #include <dirent.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdlib.h>


### PR DESCRIPTION
Functions from POSIX Threads Library are defined in <pthread.h>.