### PR TITLE
Keyword register has been deprecated in C++ 11 and removed in C++17

### DIFF
--- a/src/strutil.cc
+++ b/src/strutil.cc
@@ -107,7 +107,7 @@ int ends_with(const char *a, const char *b)
 
 /* unescapes newlines in a string */
 char *unescape_newlines(char *rawbuf) {
-  register int x, y;
+  int x, y;
 
   for(x = 0, y = 0; rawbuf[x] != (char)'\x0'; x++) {
 


### PR DESCRIPTION
The keyword `register` was used as a hint for the compiler the variables can be
inlined, but apparently, most implementations simply ignored it.

This fixes the following compilation issue with LLVM/clang 16:

strutil.cc:110:3: error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
  register int x, y;
  ^~~~~~~~~

References:
  - https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4193.html#809
  - https://en.cppreference.com/w/cpp/keyword/register