### PR TITLE
Logcache performance

### DIFF
--- a/src/LogCache.cc
+++ b/src/LogCache.cc
@@ -93,7 +93,7 @@ bool LogCache::logCachePreChecks()
         logger(LG_INFO, "Warning: no logfile found, not even %s", log_file);
         return false;
     }
-    // Has Nagios rotated logfiles? => Update
+    // Has Naemon rotated logfiles? => Update
     // our file index. And delete all memorized
     // log messages.
     if (last_log_rotation > _last_index_update) {
@@ -119,6 +119,7 @@ void LogCache::forgetLogfiles()
 
 void LogCache::updateLogfileIndex()
 {
+    logger(LG_DEBUG, "LogCache::updateLogfileIndex()");
     _last_index_update = time(0);
     // We need to find all relevant logfiles. This includes
     // directory.
@@ -151,6 +152,7 @@ void LogCache::updateLogfileIndex()
 
 void LogCache::scanLogfile(char *path, bool watch)
 {
+    logger(LG_DEBUG, "LogCache::scanLogfile: %s", path);
     Logfile *logfile = new Logfile(path, watch);
     time_t since = logfile->since();
     if (since) {

--- a/src/LogCache.cc
+++ b/src/LogCache.cc
@@ -44,7 +44,7 @@
 extern time_t last_log_rotation;
 extern int g_debug_level;
 
-#define CHECK_MEM_CYCLE 1000 /* Check memory every N'th new message */
+#define CHECK_MEM_CYCLE 10000 /* Check memory every N'th new message */
 
 // watch naemon' logfile rotation
 extern char *log_archive_path;

--- a/src/LogCache.h
+++ b/src/LogCache.h
@@ -63,7 +63,6 @@ public:
 private:
     void scanLogfile(char *path, bool watch);
     _logfiles_t::iterator findLogfileStartingBefore(time_t);
-    void dumpLogfiles();
 };
 
 #endif // LogCache_h

--- a/src/Logfile.cc
+++ b/src/Logfile.cc
@@ -169,8 +169,10 @@ long Logfile::freeMessages(unsigned logclasses)
         if ((1 << entry->_logclass) & logclasses)
         {
             delete it->second;
-            it = _entries.erase(it);
-            freed ++;
+            logfile_entries_t::iterator entry = it;
+            it++;
+            _entries.erase(entry);
+            freed++;
         } else {
             it++;
         }

--- a/src/Logfile.h
+++ b/src/Logfile.h
@@ -45,6 +45,7 @@ class Logfile
 private:
     char      *_path;
     time_t     _since;         // time of first entry
+    time_t     _end;           // time of last entry
     bool       _watch;         // true only for current logfile
     ino_t      _inode;         // needed to detect switching
     fpos_t     _read_pos;      // read until this position
@@ -63,6 +64,8 @@ public:
     void load(LogCache *LogCache, time_t since, time_t until, unsigned logclasses);
     void flush();
     time_t since() { return _since; }
+    time_t end();
+    bool watch() { return _watch; }
     unsigned classesRead() { return _logclasses_read; }
     long numEntries() { return _entries.size(); }
     logfile_entries_t* getEntriesFromQuery(Query *query, LogCache *lc, time_t since, time_t until, unsigned);
@@ -83,4 +86,3 @@ private:
 
 
 #endif // Logfile_h
-

--- a/src/OutputBuffer.h
+++ b/src/OutputBuffer.h
@@ -70,6 +70,7 @@ public:
     bool doKeepalive() { return _do_keepalive; }
     void setError(unsigned code, const char *format, ...);
     bool hasError() { return _error_message != ""; }
+    bool isAlive(int fd);
 
 private:
     void needSpace(unsigned);

--- a/src/Query.cc
+++ b/src/Query.cc
@@ -433,7 +433,7 @@ void Query::parseStatsLine(char *line)
     Column *column = _table->column(column_name);
     if (!column) {
         column = createDummyColumn(column_name);
-        logger(LOG_DEBUG, "Replacing non-existing column '%s' with null column", column_name);
+        logger(LOG_DEBUG, "%s: Replacing non-existing column '%s' with null column", _table->name(), column_name);
     }
 
     StatsColumn *stats_col;
@@ -483,7 +483,7 @@ void Query::parseFilterLine(char *line, bool is_filter)
 
     Column *column = _table->column(column_name);
     if (!column) {
-        logger(LOG_DEBUG, "Replacing non-existing column '%s' with null column", column_name);
+        logger(LOG_DEBUG, "%s: Replacing non-existing column '%s' with null column", _table->name(), column_name);
         column = createDummyColumn(column_name);
     }
 
@@ -534,7 +534,7 @@ void Query::parseSortLine(char *line)
     if( column_name != 0 ) {
         Column *column = _table->column(column_name);
         if (column == 0) {
-            logger(LOG_DEBUG, "Replacing non-existing column '%s' with null column", column_name);
+            logger(LOG_DEBUG, "%s: Replacing non-existing column '%s' with null column", _table->name(), column_name);
             column = createDummyColumn(column_name);
         }
 
@@ -576,7 +576,7 @@ void Query::parseColumnsLine(char *line)
         if (column)
             _columns.push_back(column);
         else {
-            logger(LOG_DEBUG, "Replacing non-existing column '%s' with null column", column_name);
+            logger(LOG_DEBUG, "%s: Replacing non-existing column '%s' with null column", _table->name(), column_name);
             Column *col = createDummyColumn(column_name);
             _columns.push_back(col);
         }

--- a/src/Store.cc
+++ b/src/Store.cc
@@ -41,6 +41,7 @@
 extern int g_debug_level;
 extern unsigned long g_max_cached_messages;
 extern char *qh_socket_path;
+extern Store *g_store;
 
 Store::Store()
   : _log_cache(g_max_cached_messages)
@@ -187,6 +188,11 @@ void Store::answerGetRequest(InputBuffer *input, OutputBuffer *output, const cha
     }
     Query query(input, output, table);
 
+    if(table->hasLogcache()) {
+        g_store->logCache()->lockLogCache();
+        g_store->logCache()->logCachePreChecks();
+    }
+
     if (table && !output->hasError()) {
         if (query.hasNoColumns()) {
             table->addAllColumnsToQuery(&query);
@@ -203,4 +209,7 @@ void Store::answerGetRequest(InputBuffer *input, OutputBuffer *output, const cha
         if (g_debug_level > 0)
             logger(LG_INFO, "Time to process request: %lu us. Size of answer: %d bytes", ustime, output->size());
     }
+
+    if(table->hasLogcache())
+        g_store->logCache()->unlockLogCache();
 }

--- a/src/Store.cc
+++ b/src/Store.cc
@@ -211,7 +211,8 @@ void Store::answerGetRequest(InputBuffer *input, OutputBuffer *output, const cha
         gettimeofday(&before, 0);
         query.start();
         table->answerQuery(&query);
-        query.finish();
+        if (!output->hasError()) // crashes on stats queries which result in errors before
+            query.finish();
         table->cleanupQuery(&query);
         gettimeofday(&after, 0);
         unsigned long ustime = (after.tv_sec - before.tv_sec) * 1000000 + (after.tv_usec - before.tv_usec);

--- a/src/Store.h
+++ b/src/Store.h
@@ -74,14 +74,12 @@ public:
     void registerHostgroup(hostgroup *);
     void registerComment(nebstruct_comment_data *);
     void registerDowntime(nebstruct_downtime_data *);
-    bool answerRequest(InputBuffer *, OutputBuffer *);
+    bool answerRequest(InputBuffer *, OutputBuffer *, int);
 
 private:
     Table *findTable(string name);
-    void answerGetRequest(InputBuffer *, OutputBuffer *, const char *);
+    void answerGetRequest(InputBuffer *, OutputBuffer *, const char *, int fd);
     void answerCommandRequest(const char *, OutputBuffer *);
 };
 
 #endif // Store_h
-
-

--- a/src/Table.h
+++ b/src/Table.h
@@ -57,6 +57,7 @@ public:
     virtual const char *prefixname() { return name(); }
     virtual bool isAuthorized(contact *, void *) { return true; }
     virtual void *findObject(char *objectspec __attribute__ ((__unused__))) { return 0; } // objectspec may be modified while parsing
+    virtual bool hasLogcache() { return false; };
     void clearNatSort();
     void addNatSort(string);
     void addColumn(Column *);
@@ -68,4 +69,3 @@ public:
 
 
 #endif // Table_h
-

--- a/src/TableLog.cc
+++ b/src/TableLog.cc
@@ -100,6 +100,9 @@ void TableLog::addColumns(Table *table, string prefix, int indirect_offset, bool
         g_table_services->addColumns(table, "current_service_", (char *)&(ref->_service) - (char *)ref, false /* no hosts table */);
     g_table_contacts->addColumns(table, "current_contact_", (char *)&(ref->_contact) - (char *)ref);
     g_table_commands->addColumns(table, "current_command_", (char *)&(ref->_command) - (char *)ref);
+
+    table->clearNatSort();
+    table->addNatSort( "time" );
 }
 
 

--- a/src/TableLog.h
+++ b/src/TableLog.h
@@ -41,10 +41,10 @@ public:
     const char *name() { return "log"; }
     const char *prefixname() { return "logs"; }
     bool isAuthorized(contact *ctc, void *data);
-    void handleNewMessage(Logfile *logfile, time_t since, time_t until, unsigned logclasses);
     void addColumns(Table *, string prefix, int indirect_offset, bool add_host = true, bool add_service = true);
     void answerQuery(Query *query);
     Column *column(const char *colname); // override in order to handle current_
+    bool hasLogcache() { return true; };
 
 private:
     bool answerQuery(Query *, Logfile *, time_t, time_t);

--- a/src/TableStateHistory.cc
+++ b/src/TableStateHistory.cc
@@ -204,9 +204,6 @@ void TableStateHistory::answerQuery(Query *query)
         }
     }
 
-    g_store->logCache()->lockLogCache();
-    g_store->logCache()->logCachePreChecks();
-
     // This flag might be set to true by the return value of processDataset(...)
     _abort_query = false;
 
@@ -226,14 +223,12 @@ void TableStateHistory::answerQuery(Query *query)
     _query->findIntLimits("time", &_since, &_until);
     if (_since == 0) {
         query->setError(RESPONSE_CODE_INVALID_REQUEST, "Start of timeframe required. e.g. Filter: time > 1234567890");
-        g_store->logCache()->unlockLogCache();
         return;
     }
 
     _query_timeframe = _until - _since - 1;
     if (_query_timeframe == 0) {
         query->setError(RESPONSE_CODE_INVALID_REQUEST, "Query timeframe is 0 seconds");
-        g_store->logCache()->unlockLogCache();
         return;
     }
 
@@ -251,7 +246,6 @@ void TableStateHistory::answerQuery(Query *query)
     if (_it_logs->first > _until) {
         // All logfiles are too new, invalid timeframe
         // -> No data available. Return empty result.
-        g_store->logCache()->unlockLogCache();
         return;
     }
 
@@ -544,8 +538,6 @@ void TableStateHistory::answerQuery(Query *query)
         }
     }
     object_blacklist.clear();
-
-    g_store->logCache()->unlockLogCache();
 }
 
 void TableStateHistory::cleanupQuery(Query *query) {

--- a/src/TableStateHistory.h
+++ b/src/TableStateHistory.h
@@ -67,12 +67,12 @@ public:
     const char *name() { return "statehist"; }
     const char *prefixname() { return "statehist_"; }
     bool isAuthorized(contact *ctc, void *data);
-    void handleNewMessage(Logfile *logfile, time_t since, time_t until, unsigned logclasses);
     void answerQuery(Query *query);
     void cleanupQuery(Query *query);
     Column *column(const char *colname); // override in order to handle current_
     int updateHostServiceState(Query *query, const LogEntry *entry, HostServiceState *state, const bool only_update);
     static void addColumns(Table *);
+    bool hasLogcache() { return true; };
 
 private:
     LogEntry* getPreviousLogentry();

--- a/src/logger.c
+++ b/src/logger.c
@@ -27,7 +27,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <time.h>
+#include <sys/time.h>
 #include <pthread.h>
 #include <syslog.h>
 
@@ -121,9 +121,12 @@ void logger(int priority, const char *loginfo, ...)
         if (g_logfile) {
             /* write date/time */
             char timestring[64];
-            time_t now_t = time(0);
-            struct tm now; localtime_r(&now_t, &now);
-            strftime(timestring, 64, "%F %T ", &now);
+            struct timeval tv;
+            gettimeofday(&tv, NULL);
+            struct tm now; localtime_r(&tv.tv_sec, &now);
+            strftime(timestring, 64, "[%F %T", &now);
+            fputs(timestring, g_logfile);
+            snprintf(timestring, 64, ".%03ld] ", tv.tv_usec/1000);
             fputs(timestring, g_logfile);
 
             /* write log message */

--- a/src/module.c
+++ b/src/module.c
@@ -199,7 +199,7 @@ void *client_thread(void *data)
         while (keepalive && !g_should_terminate) {
             if (g_debug_level >= 2 && requestnr > 1)
                 logger(LG_INFO, "Handling request %d on same connection", requestnr);
-            keepalive = store_answer_request(input_buffer, output_buffer);
+            keepalive = store_answer_request(input_buffer, output_buffer, cc);
             flush_output_buffer(output_buffer, cc);
             g_counters[COUNTER_REQUESTS]++;
             requestnr ++;

--- a/src/store.cc
+++ b/src/store.cc
@@ -75,9 +75,9 @@ void store_register_downtime(nebstruct_downtime_data *d)
     g_store->registerDowntime(d);
 }
 
-int store_answer_request(void *ib, void *ob)
+int store_answer_request(void *ib, void *ob, int fd)
 {
-    return g_store->answerRequest((InputBuffer *)ib, (OutputBuffer *)ob);
+    return g_store->answerRequest((InputBuffer *)ib, (OutputBuffer *)ob, fd);
 }
 
 void *create_outputbuffer(int *termination_flag)

--- a/src/store.h
+++ b/src/store.h
@@ -36,7 +36,7 @@ extern "C"
     void store_deinit();
     void store_register_comment(nebstruct_comment_data *);
     void store_register_downtime(nebstruct_downtime_data *);
-    int  store_answer_request(void *input_buffer, void *output_buffer);
+    int  store_answer_request(void *input_buffer, void *output_buffer, int fd);
     void *create_outputbuffer(int *termination_flag);
     void flush_output_buffer(void *ob, int fd);
     void delete_outputbuffer(void *);


### PR DESCRIPTION
logcache: avoid reading files outside of requested timerange
    
logfile now reads the last timestamp of a logfile as well and uses this
to select the required logfiles for a given query.
    
previously, getting logs for one day might have opened and parsed 3 logfiles.
One before the selected day, the day itself and one day afterwards. With
this patch only one file is parsed, making the logs query 3x as fast.