### PR TITLE
add display_status property to hosts and services objects

### DIFF
--- a/src/TableHosts.cc
+++ b/src/TableHosts.cc
@@ -209,6 +209,8 @@ void TableHosts::addColumns(Table *table, string prefix, int indirect_offset)
                 "The number of downtimes this host is currently in", (char *)(&hst.scheduled_downtime_depth) - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "is_executing",
                 "is there a host check currently running... (0/1)", (char *)(&hst.is_executing) - ref, indirect_offset));
+    table->addColumn(new OffsetIntColumn(prefix + "display_status",
+                "host display priority status... (0/8)", (char *)(&hst.display_status) - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "active_checks_enabled",
                 "Whether active checks are enabled for the host (0/1)", (char *)(&hst.checks_enabled) - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "check_options",

--- a/src/TableServices.cc
+++ b/src/TableServices.cc
@@ -335,6 +335,8 @@ void TableServices::addColumns(Table *table, string prefix, int indirect_offset,
                 "Whether processing of performance data is enabled for the service (0/1)", (char *)(&svc.process_performance_data) - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "is_executing",
                 "is there a service check currently running... (0/1)", (char *)(&svc.is_executing) - ref, indirect_offset));
+    table->addColumn(new OffsetIntColumn(prefix + "display_status",
+                "service display priority status... (0/8)", (char *)(&svc.display_status) - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "active_checks_enabled",
                 "Whether active checks are enabled for the service (0/1)", (char *)(&svc.checks_enabled) - ref, indirect_offset));
     table->addColumn(new OffsetIntColumn(prefix + "check_options",


### PR DESCRIPTION

This is a idea we have been using for quite sometime in order to gain performance when filtering and adding a new concept of status to naemon.

The idea is to order items by priority and as shown in the image bellow.

![status_colors](https://github.com/naemon/naemon-livestatus/assets/1627055/a2857ad8-2f4e-4b9f-825c-5427389755e0)


Before I fix any of the required steps to merge, let me see what you guys think about it.

Tks.